### PR TITLE
arm-trusted-firmware: fix bl33 not loaded in EL2

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/alsa-state/alsa-state.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/alsa-state/alsa-state.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://asound.state \
+"

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/alsa-state/files/asound.state
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/alsa-state/files/asound.state
@@ -1,0 +1,321 @@
+state.rcarsound {
+	control.1 {
+		iface MIXER
+		name 'Digital Playback Volume1'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Digital Playback Volume2'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Digital Playback Volume3'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Digital Playback Volume4'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'Digital Playback Volume5'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'Digital Playback Volume6'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'DVC Out Playback Volume'
+		value.0 83887
+		value.1 83887
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 8388607'
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'DVC Out Mute Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DVC Out Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DVC Out Ramp Up Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'DVC Out Ramp Down Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'SRC Out Rate Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'SRC Out Rate'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 192000'
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DVC In Capture Volume'
+		value.0 6710885
+		value.1 6710885
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 8388607'
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'DVC In Mute Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'DVC In Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'DVC In Ramp Up Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'DVC In Ramp Down Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+}

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/alsa-state/files/kingfisher/asound.state
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/alsa-state/files/kingfisher/asound.state
@@ -1,0 +1,321 @@
+state.ak4613 {
+	control.1 {
+		iface MIXER
+		name 'Digital Playback Volume1'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.2 {
+		iface MIXER
+		name 'Digital Playback Volume2'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.3 {
+		iface MIXER
+		name 'Digital Playback Volume3'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.4 {
+		iface MIXER
+		name 'Digital Playback Volume4'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.5 {
+		iface MIXER
+		name 'Digital Playback Volume5'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.6 {
+		iface MIXER
+		name 'Digital Playback Volume6'
+		value.0 255
+		value.1 255
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 255'
+			dbmin -9999999
+			dbmax 0
+			dbvalue.0 0
+			dbvalue.1 0
+		}
+	}
+	control.7 {
+		iface MIXER
+		name 'DVC Out Playback Volume'
+		value.0 83887
+		value.1 83887
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 8388607'
+		}
+	}
+	control.8 {
+		iface MIXER
+		name 'DVC Out Mute Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.9 {
+		iface MIXER
+		name 'DVC Out Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.10 {
+		iface MIXER
+		name 'DVC Out Ramp Up Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+	control.11 {
+		iface MIXER
+		name 'DVC Out Ramp Down Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+	control.12 {
+		iface MIXER
+		name 'SRC Out Rate Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.13 {
+		iface MIXER
+		name 'SRC Out Rate'
+		value 0
+		comment {
+			access 'read write'
+			type INTEGER
+			count 1
+			range '0 - 192000'
+		}
+	}
+	control.14 {
+		iface MIXER
+		name 'DVC In Capture Volume'
+		value.0 6710885
+		value.1 6710885
+		comment {
+			access 'read write'
+			type INTEGER
+			count 2
+			range '0 - 8388607'
+		}
+	}
+	control.15 {
+		iface MIXER
+		name 'DVC In Mute Switch'
+		value.0 false
+		value.1 false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 2
+		}
+	}
+	control.16 {
+		iface MIXER
+		name 'DVC In Ramp Switch'
+		value false
+		comment {
+			access 'read write'
+			type BOOLEAN
+			count 1
+		}
+	}
+	control.17 {
+		iface MIXER
+		name 'DVC In Ramp Up Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+	control.18 {
+		iface MIXER
+		name 'DVC In Ramp Down Rate'
+		value '128 dB/1 step'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 '128 dB/1 step'
+			item.1 '64 dB/1 step'
+			item.2 '32 dB/1 step'
+			item.3 '16 dB/1 step'
+			item.4 '8 dB/1 step'
+			item.5 '4 dB/1 step'
+			item.6 '2 dB/1 step'
+			item.7 '1 dB/1 step'
+			item.8 '0.5 dB/1 step'
+			item.9 '0.25 dB/1 step'
+			item.10 '0.125 dB/1 step'
+			item.11 '0.125 dB/2 steps'
+			item.12 '0.125 dB/4 steps'
+			item.13 '0.125 dB/8 steps'
+			item.14 '0.125 dB/16 steps'
+			item.15 '0.125 dB/32 steps'
+			item.16 '0.125 dB/64 steps'
+			item.17 '0.125 dB/128 steps'
+			item.18 '0.125 dB/256 steps'
+			item.19 '0.125 dB/512 steps'
+			item.20 '0.125 dB/1024 steps'
+			item.21 '0.125 dB/2048 steps'
+			item.22 '0.125 dB/4096 steps'
+			item.23 '0.125 dB/8192 steps'
+		}
+	}
+}

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -1,0 +1,40 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+ATFW_OPT_RPC = "${@oe.utils.conditional("DISABLE_RPC_ACCESS", "1", " RCAR_RPC_HYPERFLASH_LOCKED=1", "RCAR_RPC_HYPERFLASH_LOCKED=0", d)}"
+ADDITIONAL_ATFW_OPT_append = " ${ATFW_OPT_RPC} RCAR_BL33_EXECUTION_EL=1"
+ADDITIONAL_ATFW_OPT ??= ""
+
+SRC_URI_append = " \
+    file://0004-Enable-DAVEHD-on-R-Car-M3.patch \
+    file://0005-Change-the-security-attribute-setting-for-Cortex-R7-.patch \
+    file://0006-Kick-CR7-in-bl2.patch \
+    file://0008-ATF-Add-additional-registers-logs.patch \
+"
+
+do_compile() {
+    oe_runmake distclean
+    oe_runmake bl2 bl31 rcar_layout_tool rcar_srecord PLAT=${PLATFORM} SPD=opteed MBEDTLS_COMMON_MK=1 ${ATFW_OPT} ${ADDITIONAL_ATFW_OPT}
+}
+
+# Override the do_ipl_opt_compile function to add the ${ATFW_OPT_RPC} option
+do_ipl_opt_compile () {
+    oe_runmake distclean
+    oe_runmake bl2 bl31 rcar_layout_tool rcar_srecord PLAT=${PLATFORM} SPD=opteed MBEDTLS_COMMON_MK=1 ${EXTRA_ATFW_OPT} ${ATFW_OPT_LOSSY} ${ATFW_OPT_RPC} ${ADDITIONAL_ATFW_OPT}
+}
+
+# For IPL compile options for H3/H3ULCB (SoC: r8a7795), E3 (SoC: r8a7790)
+python do_extra_ipl_opt () {
+    soc = d.getVar('SOC_FAMILY')
+    soc = soc.split(':')[1]
+    machine = d.getVar('MACHINE_ARCH')
+
+    if soc == "r8a7795":
+        if "h3ulcb" not in machine:
+            do_extra_aft_build(d, "H3")
+        else:
+            do_extra_aft_build(d, "H3ULCB")
+
+    if soc == "r8a77990":
+        do_extra_aft_build(d, "E3")
+}
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-Revert-rcar_gen3-plat-Delete-FDT-function-calls-xt.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-Revert-rcar_gen3-plat-Delete-FDT-function-calls-xt.patch
@@ -1,0 +1,141 @@
+From b1f4fea9fbb08401892524963a2cb7d08fe57d07 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marek.vasut+renesas@gmail.com>
+Date: Sat, 17 Apr 2021 04:18:54 +0200
+Subject: [PATCH 1/4] Revert "rcar_gen3: plat: Delete FDT function calls"
+
+This reverts commit 3ebd371fa1b1137ddee85b1825d1c1ce31c719d1.
+---
+ plat/renesas/rcar/bl2_plat_setup.c | 27 ++++++++-------------------
+ 1 file changed, 8 insertions(+), 19 deletions(-)
+
+diff --git a/plat/renesas/rcar/bl2_plat_setup.c b/plat/renesas/rcar/bl2_plat_setup.c
+index 34337832c..fc657a44d 100644
+--- a/plat/renesas/rcar/bl2_plat_setup.c
++++ b/plat/renesas/rcar/bl2_plat_setup.c
+@@ -114,7 +114,6 @@ static meminfo_t bl2_tzram_layout __aligned(CACHE_WRITEBACK_GRANULE);
+ 
+ /* FDT with DRAM configuration */
+ uint64_t fdt_blob[PAGE_SIZE_4KB / sizeof(uint64_t)];
+-#if 0
+ static void *fdt = (void *)fdt_blob;
+ 
+ static void unsigned_num_print(unsigned long long int unum, unsigned int radix,
+@@ -138,7 +137,7 @@ static void unsigned_num_print(unsigned long long int unum, unsigned int radix,
+ 	while (--i >= 0)
+ 		*string++ = num_buf[i];
+ }
+-#endif
++
+ #if (RCAR_LOSSY_ENABLE == 1)
+ typedef struct bl2_lossy_info {
+ 	uint32_t magic;
+@@ -150,7 +149,6 @@ static void bl2_lossy_gen_fdt(uint32_t no, uint64_t start_addr,
+ 			      uint64_t end_addr, uint32_t format,
+ 			      uint32_t enable, int fcnlnode)
+ {
+-#if 0
+ 	const uint64_t fcnlsize = cpu_to_fdt64(end_addr - start_addr);
+ 	char nodename[40] = { 0 };
+ 	int ret, node;
+@@ -205,7 +203,6 @@ static void bl2_lossy_gen_fdt(uint32_t no, uint64_t start_addr,
+ 		NOTICE("BL2: Cannot add FCNL formats prop (ret=%i)\n", ret);
+ 		panic();
+ 	}
+-#endif
+ }
+ 
+ static void bl2_lossy_setting(uint32_t no, uint64_t start_addr,
+@@ -480,7 +477,6 @@ struct meminfo *bl2_plat_sec_mem_layout(void)
+ 	return &bl2_tzram_layout;
+ }
+ 
+-#if 0
+ static void bl2_populate_compatible_string(void *dt)
+ {
+ 	uint32_t board_type;
+@@ -569,17 +565,13 @@ static void bl2_populate_compatible_string(void *dt)
+ 		panic();
+ 	}
+ }
+-#endif
+ 
+ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ {
+-#if 0
+ 	char nodename[32] = { 0 };
+-	uint64_t fdtsize;
+-	int ret, node;
+-#endif
+ 	uint64_t start, size;
+-	int chan;
++	uint64_t fdtsize;
++	int ret, node, chan;
+ 
+ 	for (chan = 0; chan < 4; chan++) {
+ 		start = dram_config[2 * chan];
+@@ -592,7 +584,7 @@ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ 			(size >> 30) ? : size >> 20,
+ 			(size >> 30) ? "G" : "M");
+ 	}
+-#if 0
++
+ 	/*
+ 	 * We add the DT nodes in reverse order here. The fdt_add_subnode()
+ 	 * adds the DT node before the first existing DT node, so we have
+@@ -640,7 +632,6 @@ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ err:
+ 	NOTICE("BL2: Cannot add memory node to FDT (ret=%i)\n", ret);
+ 	panic();
+-#endif
+ }
+ 
+ static void bl2_advertise_dram_size(uint32_t product)
+@@ -983,7 +974,7 @@ lcm_state:
+ 		}
+ 		rcar_qos_init();
+ 	}
+-#if 0
++
+ 	/* Set up FDT */
+ 	ret = fdt_create_empty_tree(fdt, sizeof(fdt_blob));
+ 	if (ret) {
+@@ -993,7 +984,7 @@ lcm_state:
+ 
+ 	/* Add platform compatible string */
+ 	bl2_populate_compatible_string(fdt);
+-#endif
++
+ 	/* Print DRAM layout */
+ 	bl2_advertise_dram_size(product);
+ 
+@@ -1045,14 +1036,14 @@ lcm_state:
+ 	}
+ #if (RCAR_LOSSY_ENABLE == 1)
+ 	NOTICE("BL2: Lossy Decomp areas\n");
+-#if 0
++
+ 	fcnlnode = fdt_add_subnode(fdt, 0, "reserved-memory");
+ 	if (fcnlnode < 0) {
+ 		NOTICE("BL2: Cannot create reserved mem node (ret=%i)\n",
+ 			fcnlnode);
+ 		panic();
+ 	}
+-#endif
++
+ 	bl2_lossy_setting(0, LOSSY_ST_ADDR0, LOSSY_END_ADDR0,
+ 			  LOSSY_FMT0, LOSSY_ENA_DIS0, fcnlnode);
+ 	bl2_lossy_setting(1, LOSSY_ST_ADDR1, LOSSY_END_ADDR1,
+@@ -1061,10 +1052,8 @@ lcm_state:
+ 			  LOSSY_FMT2, LOSSY_ENA_DIS2, fcnlnode);
+ #endif
+ 
+-#if 0
+ 	fdt_pack(fdt);
+ 	NOTICE("BL2: FDT at %p\n", fdt);
+-#endif
+ 
+ 	if (boot_dev == MODEMR_BOOT_DEV_EMMC_25X1 ||
+ 	    boot_dev == MODEMR_BOOT_DEV_EMMC_50X8)
+-- 
+2.30.2
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-Revert-rcar_gen3-plat-Delete-FDT-function-calls.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-Revert-rcar_gen3-plat-Delete-FDT-function-calls.patch
@@ -1,0 +1,141 @@
+From b1f4fea9fbb08401892524963a2cb7d08fe57d07 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marek.vasut+renesas@gmail.com>
+Date: Sat, 17 Apr 2021 04:18:54 +0200
+Subject: [PATCH 1/4] Revert "rcar_gen3: plat: Delete FDT function calls"
+
+This reverts commit 3ebd371fa1b1137ddee85b1825d1c1ce31c719d1.
+---
+ plat/renesas/rcar/bl2_plat_setup.c | 27 ++++++++-------------------
+ 1 file changed, 8 insertions(+), 19 deletions(-)
+
+diff --git a/plat/renesas/rcar/bl2_plat_setup.c b/plat/renesas/rcar/bl2_plat_setup.c
+index 34337832c..fc657a44d 100644
+--- a/plat/renesas/rcar/bl2_plat_setup.c
++++ b/plat/renesas/rcar/bl2_plat_setup.c
+@@ -114,7 +114,6 @@ static meminfo_t bl2_tzram_layout __aligned(CACHE_WRITEBACK_GRANULE);
+ 
+ /* FDT with DRAM configuration */
+ uint64_t fdt_blob[PAGE_SIZE_4KB / sizeof(uint64_t)];
+-#if 0
+ static void *fdt = (void *)fdt_blob;
+ 
+ static void unsigned_num_print(unsigned long long int unum, unsigned int radix,
+@@ -138,7 +137,7 @@ static void unsigned_num_print(unsigned long long int unum, unsigned int radix,
+ 	while (--i >= 0)
+ 		*string++ = num_buf[i];
+ }
+-#endif
++
+ #if (RCAR_LOSSY_ENABLE == 1)
+ typedef struct bl2_lossy_info {
+ 	uint32_t magic;
+@@ -150,7 +149,6 @@ static void bl2_lossy_gen_fdt(uint32_t no, uint64_t start_addr,
+ 			      uint64_t end_addr, uint32_t format,
+ 			      uint32_t enable, int fcnlnode)
+ {
+-#if 0
+ 	const uint64_t fcnlsize = cpu_to_fdt64(end_addr - start_addr);
+ 	char nodename[40] = { 0 };
+ 	int ret, node;
+@@ -205,7 +203,6 @@ static void bl2_lossy_gen_fdt(uint32_t no, uint64_t start_addr,
+ 		NOTICE("BL2: Cannot add FCNL formats prop (ret=%i)\n", ret);
+ 		panic();
+ 	}
+-#endif
+ }
+ 
+ static void bl2_lossy_setting(uint32_t no, uint64_t start_addr,
+@@ -480,7 +477,6 @@ struct meminfo *bl2_plat_sec_mem_layout(void)
+ 	return &bl2_tzram_layout;
+ }
+ 
+-#if 0
+ static void bl2_populate_compatible_string(void *dt)
+ {
+ 	uint32_t board_type;
+@@ -569,17 +565,13 @@ static void bl2_populate_compatible_string(void *dt)
+ 		panic();
+ 	}
+ }
+-#endif
+ 
+ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ {
+-#if 0
+ 	char nodename[32] = { 0 };
+-	uint64_t fdtsize;
+-	int ret, node;
+-#endif
+ 	uint64_t start, size;
+-	int chan;
++	uint64_t fdtsize;
++	int ret, node, chan;
+ 
+ 	for (chan = 0; chan < 4; chan++) {
+ 		start = dram_config[2 * chan];
+@@ -592,7 +584,7 @@ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ 			(size >> 30) ? : size >> 20,
+ 			(size >> 30) ? "G" : "M");
+ 	}
+-#if 0
++
+ 	/*
+ 	 * We add the DT nodes in reverse order here. The fdt_add_subnode()
+ 	 * adds the DT node before the first existing DT node, so we have
+@@ -640,7 +632,6 @@ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ err:
+ 	NOTICE("BL2: Cannot add memory node to FDT (ret=%i)\n", ret);
+ 	panic();
+-#endif
+ }
+ 
+ static void bl2_advertise_dram_size(uint32_t product)
+@@ -983,7 +974,7 @@ lcm_state:
+ 		}
+ 		rcar_qos_init();
+ 	}
+-#if 0
++
+ 	/* Set up FDT */
+ 	ret = fdt_create_empty_tree(fdt, sizeof(fdt_blob));
+ 	if (ret) {
+@@ -993,7 +984,7 @@ lcm_state:
+ 
+ 	/* Add platform compatible string */
+ 	bl2_populate_compatible_string(fdt);
+-#endif
++
+ 	/* Print DRAM layout */
+ 	bl2_advertise_dram_size(product);
+ 
+@@ -1045,14 +1036,14 @@ lcm_state:
+ 	}
+ #if (RCAR_LOSSY_ENABLE == 1)
+ 	NOTICE("BL2: Lossy Decomp areas\n");
+-#if 0
++
+ 	fcnlnode = fdt_add_subnode(fdt, 0, "reserved-memory");
+ 	if (fcnlnode < 0) {
+ 		NOTICE("BL2: Cannot create reserved mem node (ret=%i)\n",
+ 			fcnlnode);
+ 		panic();
+ 	}
+-#endif
++
+ 	bl2_lossy_setting(0, LOSSY_ST_ADDR0, LOSSY_END_ADDR0,
+ 			  LOSSY_FMT0, LOSSY_ENA_DIS0, fcnlnode);
+ 	bl2_lossy_setting(1, LOSSY_ST_ADDR1, LOSSY_END_ADDR1,
+@@ -1061,10 +1052,8 @@ lcm_state:
+ 			  LOSSY_FMT2, LOSSY_ENA_DIS2, fcnlnode);
+ #endif
+ 
+-#if 0
+ 	fdt_pack(fdt);
+ 	NOTICE("BL2: FDT at %p\n", fdt);
+-#endif
+ 
+ 	if (boot_dev == MODEMR_BOOT_DEV_EMMC_25X1 ||
+ 	    boot_dev == MODEMR_BOOT_DEV_EMMC_50X8)
+-- 
+2.30.2
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0002-rcar_gen3-plat-Fix-DRAM-size-judgment-by-PRR-registe.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0002-rcar_gen3-plat-Fix-DRAM-size-judgment-by-PRR-registe.patch
@@ -1,0 +1,49 @@
+From 44d8a2f1a0c42b7525c0280b01a73996c2fbabe6 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marek.vasut+renesas@gmail.com>
+Date: Thu, 22 Apr 2021 00:55:36 +0200
+Subject: [PATCH 2/4] rcar_gen3: plat: Fix DRAM size judgment by PRR register
+
+The even dram_config[] array fields contain DRAM bank base addresses,
+while odd dram_config[] array fields contain DRAM bank size. Fix the
+assignment for M3W.
+
+2 GiB M3W has 1 GiB DRAM at bank 0x4_0000_0000 and 1 GiB at 0x6_0000_0000,
+4 GiB M3W has 2 GiB DRAM at bank 0x4_0000_0000 and 2 GiB at 0x6_0000_0000.
+
+Fixes: 65755155e ("rcar_gen3: plat: Add DRAM size judgment by PRR register")
+Signed-off-by: Marek Vasut <marek.vasut+renesas@gmail.com>
+Change-Id: Id2938d1d8ee4a81d6bca7a977eae3d6174c3fdb4
+---
+ plat/renesas/rcar/bl2_plat_setup.c | 9 +++------
+ 1 file changed, 3 insertions(+), 6 deletions(-)
+
+diff --git a/plat/renesas/rcar/bl2_plat_setup.c b/plat/renesas/rcar/bl2_plat_setup.c
+index fc657a44d..038601188 100644
+--- a/plat/renesas/rcar/bl2_plat_setup.c
++++ b/plat/renesas/rcar/bl2_plat_setup.c
+@@ -672,19 +672,16 @@ static void bl2_advertise_dram_size(uint32_t product)
+ #if (RCAR_GEN3_ULCB == 1)
+ 			/* 2GB(1GBx2 2ch split) */
+ 			dram_config[1] = 0x40000000ULL;
+-			dram_config[2] = 0x600000000ULL;
+-			dram_config[3] = 0x40000000ULL;
++			dram_config[5] = 0x40000000ULL;
+ #else
+ 			/* 4GB(2GBx2 2ch split) */
+ 			dram_config[1] = 0x80000000ULL;
+-			dram_config[2] = 0x600000000ULL;
+-			dram_config[3] = 0x80000000ULL;
++			dram_config[5] = 0x80000000ULL;
+ #endif
+ 		} else {
+ 			/* 8GB(2GBx4 2ch split) */
+ 			dram_config[1] = 0x100000000ULL;
+-			dram_config[2] = 0x600000000ULL;
+-			dram_config[3] = 0x100000000ULL;
++			dram_config[5] = 0x100000000ULL;
+ 		}
+ 		break;
+ 
+-- 
+2.30.2
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0003-rcar_gen3-plat-Factor-out-DT-memory-node-generation.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0003-rcar_gen3-plat-Factor-out-DT-memory-node-generation.patch
@@ -1,0 +1,105 @@
+From 78d13b9acf6e76ad536f6352a3f73e48e5790822 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marek.vasut+renesas@gmail.com>
+Date: Fri, 16 Apr 2021 21:25:27 +0200
+Subject: [PATCH 3/4] rcar_gen3: plat: Factor out DT memory node generation
+
+Move the code that adds single new memory@ node into the DT fragment passed
+to system software into separate function. Adjust the failure message to be
+more specific and print the address range of node which failed to be added.
+No functional change.
+
+Signed-off-by: Marek Vasut <marek.vasut+renesas@gmail.com>
+Change-Id: Ie42cd7756b045271f070bca93c524fff6238f5a2
+---
+ plat/renesas/rcar/bl2_plat_setup.c | 64 +++++++++++++++++-------------
+ 1 file changed, 36 insertions(+), 28 deletions(-)
+
+diff --git a/plat/renesas/rcar/bl2_plat_setup.c b/plat/renesas/rcar/bl2_plat_setup.c
+index 038601188..d4fcc3900 100644
+--- a/plat/renesas/rcar/bl2_plat_setup.c
++++ b/plat/renesas/rcar/bl2_plat_setup.c
+@@ -566,12 +566,44 @@ static void bl2_populate_compatible_string(void *dt)
+ 	}
+ }
+ 
+-static void bl2_advertise_dram_entries(uint64_t dram_config[8])
++static void bl2_add_dram_entry(uint64_t start, uint64_t size)
+ {
+ 	char nodename[32] = { 0 };
+-	uint64_t start, size;
+ 	uint64_t fdtsize;
+-	int ret, node, chan;
++	int ret, node;
++
++	fdtsize = cpu_to_fdt64(size);
++
++	snprintf(nodename, sizeof(nodename), "memory@");
++	unsigned_num_print(start, 16, nodename + strlen(nodename));
++	node = ret = fdt_add_subnode(fdt, 0, nodename);
++	if (ret < 0)
++		goto err;
++
++	ret = fdt_setprop_string(fdt, node, "device_type", "memory");
++	if (ret < 0)
++		goto err;
++
++	ret = fdt_setprop_u64(fdt, node, "reg", start);
++	if (ret < 0)
++		goto err;
++
++	ret = fdt_appendprop(fdt, node, "reg", &fdtsize,
++			     sizeof(fdtsize));
++	if (ret < 0)
++		goto err;
++
++	return;
++err:
++	NOTICE("BL2: Cannot add memory node [%llx - %llx] to FDT (ret=%i)\n",
++		start, start + size - 1, ret);
++	panic();
++}
++
++static void bl2_advertise_dram_entries(uint64_t dram_config[8])
++{
++	uint64_t start, size;
++	int chan;
+ 
+ 	for (chan = 0; chan < 4; chan++) {
+ 		start = dram_config[2 * chan];
+@@ -606,32 +638,8 @@ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ 			size -= 0x8000000;
+ 		}
+ 
+-		fdtsize = cpu_to_fdt64(size);
+-
+-		snprintf(nodename, sizeof(nodename), "memory@");
+-		unsigned_num_print(start, 16, nodename + strlen(nodename));
+-		node = ret = fdt_add_subnode(fdt, 0, nodename);
+-		if (ret < 0)
+-			goto err;
+-
+-		ret = fdt_setprop_string(fdt, node, "device_type", "memory");
+-		if (ret < 0)
+-			goto err;
+-
+-		ret = fdt_setprop_u64(fdt, node, "reg", start);
+-		if (ret < 0)
+-			goto err;
+-
+-		ret = fdt_appendprop(fdt, node, "reg", &fdtsize,
+-				     sizeof(fdtsize));
+-		if (ret < 0)
+-			goto err;
++		bl2_add_dram_entry(start, size);
+ 	}
+-
+-	return;
+-err:
+-	NOTICE("BL2: Cannot add memory node to FDT (ret=%i)\n", ret);
+-	panic();
+ }
+ 
+ static void bl2_advertise_dram_size(uint32_t product)
+-- 
+2.30.2
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0004-Enable-DAVEHD-on-R-Car-M3.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0004-Enable-DAVEHD-on-R-Car-M3.patch
@@ -1,0 +1,25 @@
+From adece3414bedef44406bc5d08f130af1a65fc6b7 Mon Sep 17 00:00:00 2001
+From: Vito Colagiacomo <vito.colagiacomo@renesas.com>
+Date: Tue, 21 Aug 2018 12:54:34 +0200
+Subject: [PATCH 1/3] Enable DAVEHD on R-Car M3
+
+---
+ plat/renesas/rcar/bl2_cpg_init.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plat/renesas/rcar/bl2_cpg_init.c b/plat/renesas/rcar/bl2_cpg_init.c
+index 6c3c969a9..22c6eb4d2 100644
+--- a/plat/renesas/rcar/bl2_cpg_init.c
++++ b/plat/renesas/rcar/bl2_cpg_init.c
+@@ -85,7 +85,7 @@ static void bl2_secure_cpg_init(void)
+ 	cpg_write(SCMSTPCR5, stop_cr5);
+ 	cpg_write(SCMSTPCR6, 0xFFFFFFFFU);
+ 	cpg_write(SCMSTPCR7, 0xFFFFFFFFU);
+-	cpg_write(SCMSTPCR8, 0xFFFFFFFFU);
++	cpg_write(SCMSTPCR8, 0xFFFFFFFDU);
+ 	cpg_write(SCMSTPCR9, 0xFFFDFFFFU);
+ 	cpg_write(SCMSTPCR10, 0xFFFFFFFFU);
+ 	cpg_write(SCMSTPCR11, 0xFFFFFFFFU);
+-- 
+2.17.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0004-rcar_gen3-plat-Generate-two-memory-nodes-for-larger-.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0004-rcar_gen3-plat-Generate-two-memory-nodes-for-larger-.patch
@@ -1,0 +1,83 @@
+From c84e650cf4ba6bef46d23c769fb23ae715400437 Mon Sep 17 00:00:00 2001
+From: Marek Vasut <marek.vasut+renesas@gmail.com>
+Date: Fri, 16 Apr 2021 21:39:36 +0200
+Subject: [PATCH V2 4/4] rcar_gen3: plat: Generate two memory nodes for larger
+ than 2 GiB channel 0
+
+The DRAM channel 0 memory area in 32bit space is limited to 2 GiB window.
+Furthermore, the first 128 MiB of this memory window are reserved and not
+accessible by the system software, hence the 32bit area memory node is
+limited to range 0x4800_0000..0xbfff_ffff.
+
+In case there are more than 2 GiB of DRAM populated in channel 0, it is
+necessary to generate two memory nodes, once covering the 2 GiB - 128 MiB
+area in the 32bit space, and another covering the rest of the memory in
+64bit space. This patch implements handling of such a case.
+
+Signed-off-by: Marek Vasut <marek.vasut+renesas@gmail.com>
+Change-Id: I3495241fb938e355352e817afaca8f01d04c81d2
+---
+V2: Actually decrement the size32 by 128 MiB, so that on 1 GiB bank
+    we won't end up generating [ 48000000 -  87ffffff] node, but
+    rather [ 48000000 -  7fffffff] node.
+---
+ plat/renesas/rcar/bl2_plat_setup.c | 34 ++++++++++++++++++++++++++----
+ 1 file changed, 30 insertions(+), 4 deletions(-)
+
+diff --git a/plat/renesas/rcar/bl2_plat_setup.c b/plat/renesas/rcar/bl2_plat_setup.c
+index d4fcc3900..4d4f8220b 100644
+--- a/plat/renesas/rcar/bl2_plat_setup.c
++++ b/plat/renesas/rcar/bl2_plat_setup.c
+@@ -602,7 +602,7 @@ err:
+ 
+ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ {
+-	uint64_t start, size;
++	uint64_t start, size, size32;
+ 	int chan;
+ 
+ 	for (chan = 0; chan < 4; chan++) {
+@@ -631,11 +631,37 @@ static void bl2_advertise_dram_entries(uint64_t dram_config[8])
+ 
+ 		/*
+ 		 * Channel 0 is mapped in 32bit space and the first
+-		 * 128 MiB are reserved
++		 * 128 MiB are reserved and the maximum size is 2GiB.
+ 		 */
+ 		if (chan == 0) {
+-			start = 0x48000000;
+-			size -= 0x8000000;
++			/* Limit the 32bit entry to 2 GiB - 128 MiB */
++			size32 = size - 0x8000000;
++			if (size32 >= 0x78000000)
++				size32 = 0x78000000;
++
++			/* Emit 32bit entry, up to 2 GiB - 128 MiB long. */
++			bl2_add_dram_entry(0x48000000, size32);
++
++			/*
++			 * If channel 0 is less than 2 GiB long, the
++			 * entire memory fits into the 32bit space entry,
++			 * so move on to the next channel.
++			 */
++			if (size <= 0x80000000)
++				continue;
++
++			/*
++			 * If channel 0 is more than 2 GiB long, emit
++			 * another entry which covers the rest of the
++			 * memory in channel 0, in the 64bit space.
++			 *
++			 * Start of this new entry is at 2 GiB offset
++			 * from the beginning of the 64bit channel 0
++			 * address, size is 2 GiB shorter than total
++			 * size of the channel.
++			 */
++			start += 0x80000000;
++			size -= 0x80000000;
+ 		}
+ 
+ 		bl2_add_dram_entry(start, size);
+-- 
+2.30.2
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0005-Change-the-security-attribute-setting-for-Cortex-R7-.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0005-Change-the-security-attribute-setting-for-Cortex-R7-.patch
@@ -1,0 +1,28 @@
+From 7c7effdc95250cda577e288abf7d8c906d56183b Mon Sep 17 00:00:00 2001
+From: Vito Colagiacomo <vito.colagiacomo@renesas.com>
+Date: Tue, 21 Aug 2018 12:55:34 +0200
+Subject: [PATCH 2/3] Change the security attribute setting for Cortex-R7
+ master port to "Secure"
+
+This way the CR7 has enough privileges to set protected registers of
+INTC-RT.
+---
+ plat/renesas/rcar/bl2_secure_setting.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/plat/renesas/rcar/bl2_secure_setting.c b/plat/renesas/rcar/bl2_secure_setting.c
+index 7b72bcf8b..b4ae37ae1 100644
+--- a/plat/renesas/rcar/bl2_secure_setting.c
++++ b/plat/renesas/rcar/bl2_secure_setting.c
+@@ -23,7 +23,7 @@ static const struct {
+ 	/* Bit 0: ARM realtime core (Cortex-R7) master port             */
+ 	/*       0: Non-Secure                                          */
+ 	{
+-	SEC_SRC, 0x0000001EU},
++	SEC_SRC, 0x0000001FU},
+ 	/** Security attribute setting for slave ports 0 to 15		*/
+ 	    /*      {SEC_SEL0,              0xFFFFFFFFU},                   */
+ 	    /*      {SEC_SEL1,              0xFFFFFFFFU},                   */
+-- 
+2.17.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0006-Kick-CR7-in-bl2.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0006-Kick-CR7-in-bl2.patch
@@ -1,0 +1,134 @@
+From 31a5f0ee5fcb5ce7eca2fe4fe43926b2a4643729 Mon Sep 17 00:00:00 2001
+From: valerii chubar <sdfs@com>
+Date: Tue, 21 Aug 2018 12:55:34 +0200
+Subject: [PATCH] Kick CR7 in bl2
+
+TODO: check if rcar_dma_init() if redundant
+
+---
+ bl2/bl2_main.c | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 85 insertions(+)
+
+diff --git a/bl2/bl2_main.c b/bl2/bl2_main.c
+index 802c17464..0cf2d9ded 100644
+--- a/bl2/bl2_main.c
++++ b/bl2/bl2_main.c
+@@ -18,6 +18,10 @@
+ #include <plat/common/platform.h>
+ 
+ #include "bl2_private.h"
++#include <lib/mmio.h>
++
++extern void rcar_dma_init(void);
++extern void rcar_dma_exec(uintptr_t dst, uint32_t src, uint32_t len);
+ 
+ #ifdef __aarch64__
+ #define NEXT_IMAGE	"BL31"
+@@ -25,6 +29,77 @@
+ #define NEXT_IMAGE	"BL32"
+ #endif
+ 
++#define LOC_CR7_CODE_ADDR      0x70000000
++
++#define LOC_CPG_CPGWPR         0xe6150900
++#define LOC_CPG_CPGWPCR        0xe6150904
++
++#define LOC_RST_CR7BAR         0xe6160070
++
++#define LOC_APMU_CR7PSTR       0xe6153040
++
++#define LOC_SYSC_PWRSR7        0xe6180240
++#define LOC_SYSC_PWRONCR7      0xe618024c
++
++
++#define LOC_CR7_WBCTLR         0xf0100000
++#define LOC_CR7_WBPWRCTLR      0xf0100f80
++
++#define LOC_MSSR_BASE          0xe6150000
++#define LOC_MSSR_SRCR2         0xe61500B0
++#define LOC_MSSR_SRSTCLR2      0xe6150948
++
++#define FLASH_BASE             (0x08000000U)
++#define FLASH_RTOS_IMAGE_ADDR  (0x02000000U) // Reserve above for others BL33
++#define FLASH_RTOS_IMAGESIZE   (32*1024*1024) // All remain flash memory size
++#define FLASH_RTOS_MMAP_ADDR   (FLASH_BASE + FLASH_RTOS_IMAGE_ADDR)
++
++static void locCPGReadModWriteRegSet(uint32_t Addr, uint32_t Mask){
++    uint32_t val;
++
++    mmio_write_32(LOC_CPG_CPGWPCR, 0xa5a50000);    /* Clear register protection */
++    val = mmio_read_32(Addr) | Mask;         /* Generate value */
++    mmio_write_32(LOC_CPG_CPGWPR, ~val);          /* Unlock write */
++    mmio_write_32(Addr,val);                 /* Write value */
++}
++
++static void Kick_CR7(void) {
++    uint32_t regval;
++
++    mmio_write_32(LOC_CPG_CPGWPCR, 0xa5a50000);
++
++    mmio_write_32(LOC_CPG_CPGWPR, 0xffbfffff);
++
++    regval = (LOC_CR7_CODE_ADDR & 0xfffc0000);
++    mmio_write_32(LOC_RST_CR7BAR, regval);
++    regval |= 0x10;
++    mmio_write_32(LOC_RST_CR7BAR, regval);
++
++    mmio_write_32(LOC_SYSC_PWRONCR7, 0x1);
++
++    do {
++        regval = (mmio_read_32(LOC_APMU_CR7PSTR) & 0x3);
++        regval |= (mmio_read_32(LOC_SYSC_PWRSR7) & 0x10);
++    } while (regval != 0x10);
++
++    locCPGReadModWriteRegSet(LOC_MSSR_SRCR2, 0x00400000);
++/* FIXME: to be investigated. The commented code should (acc. to HW-Manual) be used
++ * in the core startup, however it creates yet to be investigated problems:
++ * 1. After this code sequence the linux kernel cannot start (data abort exception).
++ * 2. It is also incompatible to R-Car Inspect, there this is commented as well */
++#if 0
++    regval = mmio_read_32(LOC_CR7_WBCTLR);
++    regval |= 0x1;
++    mmio_write_32(LOC_CR7_WBCTLR, regval);
++
++    regval = mmio_read_32(LOC_CR7_WBPWRCTLR);
++    regval |= 0x1;
++    mmio_write_32(LOC_CR7_WBPWRCTLR, regval);
++#endif
++    locCPGReadModWriteRegSet(LOC_MSSR_SRSTCLR2, 0x00400000);
++}
++
++
+ #if !BL2_AT_EL3
+ /*******************************************************************************
+  * Setup function for BL2.
+@@ -93,9 +168,18 @@ void bl2_main(void)
+ 	/* initialize boot source */
+ 	bl2_plat_preload_setup();
+ 
++
++
++	/* Load ROS image */
++	rcar_dma_init();
++	rcar_dma_exec(LOC_CR7_CODE_ADDR, FLASH_RTOS_MMAP_ADDR, FLASH_RTOS_IMAGESIZE);
++	// execDMA(LOC_CR7_CODE_ADDR, FLASH_RTOS_MMAP_ADDR, FLASH_RTOS_IMAGESIZE);
++
+ 	/* Load the subsequent bootloader images. */
+ 	next_bl_ep_info = bl2_load_images();
+ 
++	Kick_CR7();
++
+ #if !BL2_AT_EL3
+ #ifndef __aarch64__
+ 	/*
+@@ -126,6 +210,7 @@ void bl2_main(void)
+ 	print_entry_point_info(next_bl_ep_info);
+ 	console_flush();
+ 
++
+ #if ENABLE_PAUTH
+ 	/*
+ 	 * Disable pointer authentication before running next boot image
+-- 
+2.17.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0007-plat-renesas-rcar-bl31-Enable-RPC-access-if-necessar.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0007-plat-renesas-rcar-bl31-Enable-RPC-access-if-necessar.patch
@@ -1,0 +1,34 @@
+From 0c24956262824f20e7b907034018b1e1b6b2b4ab Mon Sep 17 00:00:00 2001
+From: Valentine Barshak <valentine.barshak@cogentembedded.com>
+Date: Thu, 11 Feb 2021 20:15:02 +0300
+Subject: [PATCH 1/6] plat: renesas: rcar: bl31: Enable RPC access if necessary
+
+This enables RPC flash access before leaving BL31
+in case RCAR_RPC_HYPERFLASH_LOCKED is disabled.
+
+Signed-off-by: Valentine Barshak <valentine.barshak@cogentembedded.com>
+---
+ plat/renesas/rcar/bl31_plat_setup.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/plat/renesas/rcar/bl31_plat_setup.c b/plat/renesas/rcar/bl31_plat_setup.c
+index 8dd3a5f..c1ec987 100644
+--- a/plat/renesas/rcar/bl31_plat_setup.c
++++ b/plat/renesas/rcar/bl31_plat_setup.c
+@@ -141,3 +141,13 @@ uint32_t bl31_plat_boot_mpidr_chk(void)
+ 	return rc;
+ }
+ 
++void bl31_plat_runtime_setup(void)
++{
++#if (RCAR_RPC_HYPERFLASH_LOCKED == 0)
++	/* Enable non-secure access to the RPC HyperFlash region. */
++	mmio_write_32(0xee2000b8, 0x155);
++	mmio_write_32(0xee200000, mmio_read_32(0xee200000) & 0x7fffffff);
++#endif
++
++	console_switch_state(CONSOLE_FLAG_RUNTIME);
++}
+-- 
+2.7.4
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0008-ATF-Add-additional-registers-logs.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0008-ATF-Add-additional-registers-logs.patch
@@ -1,0 +1,26 @@
+From 0d38f7bcd63e0181e0ba22b6047511c2580810cb Mon Sep 17 00:00:00 2001
+From: Valerii Chubar <valerii_chubar@epam.com>
+Date: Wed, 7 Jul 2021 15:34:09 +0300
+Subject: [PATCH] ATF: Add additional registers logs
+
+---
+ bl31/aarch64/crash_reporting.S | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/bl31/aarch64/crash_reporting.S b/bl31/aarch64/crash_reporting.S
+index d56b513b8..f05f36e19 100644
+--- a/bl31/aarch64/crash_reporting.S
++++ b/bl31/aarch64/crash_reporting.S
+@@ -48,7 +48,8 @@ non_el3_sys_regs:
+ 		"mair_el1", "amair_el1", "tcr_el1", "tpidr_el1", "tpidr_el0",\
+ 		"tpidrro_el0",  "par_el1", "mpidr_el1", "afsr0_el1", "afsr1_el1",\
+ 		"contextidr_el1", "vbar_el1", "cntp_ctl_el0", "cntp_cval_el0",\
+-		"cntv_ctl_el0", "cntv_cval_el0", "cntkctl_el1", "sp_el0", "isr_el1", ""
++		"cntv_ctl_el0", "cntv_cval_el0", "cntkctl_el1", "sp_el0", "isr_el1", \
++		"elr_el2", "esr_el2", "far_el2", ""
+ 
+ #if CTX_INCLUDE_AARCH32_REGS
+ aarch32_regs:
+-- 
+2.17.1
+


### PR DESCRIPTION
RCAR_BL33_EXECUTION_EL=1 option not really gets passed to IPL compile command,
so xen is started in EL1 mode

Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>