### PR TITLE
dom0: Remove modifications of doma.service file

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/doma.bbappend
@@ -5,25 +5,21 @@ RDEPENDS_${PN} += "backend-ready"
 SRC_URI += "\
     file://doma-vdevices.cfg \
     file://doma-set-root \
+    file://doma-set-root.conf \
 "
 
 FILES_${PN} += " \
     ${libdir}/xen/bin/doma-set-root \
+    ${sysconfdir}/systemd/system/doma.service.d/doma-set-root.conf \
 "
 
 do_install_append() {
     cat ${WORKDIR}/doma-vdevices.cfg >> ${D}${sysconfdir}/xen/doma.cfg
 
-    # Install doma-set-root script
+    # Install doma-set-root script and the drop-in file to run it
     install -d ${D}${libdir}/xen/bin
     install -m 0744 ${WORKDIR}/doma-set-root ${D}${libdir}/xen/bin
 
-    # Call doma-set-root script
-    sed -i 's/backend-ready.*/domd.service/' ${D}${systemd_unitdir}/system/doma.service
-    # remove the dependency on sndbe and display backend - sound belongs to android, 
-    # display backend does not exists
-    sed -r 's/backend-ready@sndbe.service//' ${D}${systemd_unitdir}/system/doma.service
-    sed -r 's/backend-ready@displbe.service//' ${D}${systemd_unitdir}/system/doma.service
-    echo "[Service]" >> ${D}${systemd_unitdir}/system/doma.service
-    echo "ExecStartPre=${libdir}/xen/bin/doma-set-root" >> ${D}${systemd_unitdir}/system/doma.service
+    install -d ${D}${sysconfdir}/systemd/system/doma.service.d
+    install -m 0644 ${WORKDIR}/doma-set-root.conf ${D}${sysconfdir}/systemd/system/doma.service.d
 }

--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-set-root.conf
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-set-root.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/lib/xen/bin/doma-set-root


### PR DESCRIPTION
There are no dependencies on sndbe and displbe inside doma.service,
so no need for modifications in our append.

Also, call of doma-set-root is remade as systemd drop-in file.

-----
NOTE: must be merged after https://github.com/xen-troops/meta-xt-common/pull/20