### PR TITLE
cluster_wrapper: add toolchain to build cluster.

### DIFF
--- a/meta-xt-prod-cockpit-rcar-cluster/recipes-cluster/cluster-bin/cluster-wrapper-toolchain-native.bb
+++ b/meta-xt-prod-cockpit-rcar-cluster/recipes-cluster/cluster-bin/cluster-wrapper-toolchain-native.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "Toolchain to build cluster-wrapper"
+LICENSE = "CLOSED"
+
+inherit native
+
+PV = "10-2020-q4-major"
+
+SRC_URI = " \
+    https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-${PV}-x86_64-linux.tar.bz2 \
+"
+
+INSANE_SKIP_${PN} = "already-stripped"
+SRC_URI[sha256sum] = "21134caa478bbf5352e239fbc6e2da3038f8d2207e089efc96c3b55f1edcd618"
+SRC_URI[md5sum] = "8312c4c91799885f222f663fc81f9a31"
+
+
+FILES_${PN} = "${datadir} ${bindir}"
+
+do_install() {
+
+    install -d ${D}${datadir}/arm-none-eabi-${PV}/
+    cp -r ${S}/../gcc-arm-none-eabi-${PV}/* ${D}${datadir}/
+
+    install -d ${D}${bindir}
+    # Symlink all executables into bindir
+    for f in ${D}${datadir}/bin/arm-none-eabi-*; do
+        lnr $f ${D}${bindir}/$(basename $f)
+    done
+}
+

--- a/meta-xt-prod-cockpit-rcar-cluster/recipes-cluster/cluster-bin/cluster-wrapper_git.bb
+++ b/meta-xt-prod-cockpit-rcar-cluster/recipes-cluster/cluster-bin/cluster-wrapper_git.bb
@@ -4,6 +4,12 @@ DESCRIPTION = "build of cluster_bin"
 
 LICENSE = "CLOSED"
 
+inherit deploy
+
+PLATFORM = "rcar"
+
+PARALLEL_MAKE = ""
+
 SRC_URI = " \
    git://git@gitpct.epam.com/epmd-aepr/vlib;protocol=ssh;branch=vlib-root \
 "
@@ -11,10 +17,11 @@ SRC_URI = " \
 SRCREV = "${AUTOREV}"
 
 DEPENDS = " \
-   gcc-arm-none-eabi-native \
+    cluster-wrapper-toolchain-native \
 "
+
 do_compile() {
-    make -C "${WORKDIR}/git/app/cluster_wrapper/target/arm-gnu-freertos_cr7_r-carx3"
+     oe_runmake -C "${WORKDIR}/git/app/cluster_wrapper/target/arm-gnu-freertos_cr7_r-carx3"
 }
 
 do_install() {


### PR DESCRIPTION
The toolchain from meta-arm produces the binary file
that does not work. The version  10-2020-q4-major of arm-none-eabi
produces good binary file.

Signed-off-by: Ihor Usyk <ihor.usyk@gmail.com>