### PR TITLE
domd: add IO performance utilities to the resulting image

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
@@ -11,6 +11,8 @@ IMAGE_INSTALL_append = " \
     util-linux \
     dnsmasq \
     optee-os \
+    fio \
+    iotop \
 "
 
 IMAGE_INSTALL_remove = " \


### PR DESCRIPTION
Add iotop and fio to be able to measure IO.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>