### PR TITLE
dom0: add xentop to the resulting image

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -1,0 +1,1 @@
+IMAGE_INSTALL_append = " xen-tools-xenstat"


### PR DESCRIPTION
Add xen-tools-xenstat, which provides xentop
to the resulting dom0 image.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>