### PR TITLE
doma: do not force DHCP for linux kernel

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-h3ulcb-4x2g-kf.cfg
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-h3ulcb-4x2g-kf.cfg
@@ -175,7 +175,7 @@ dt_passthrough_nodes = [
 ]
 
 # Kernel command line options
-extra = "ip=dhcp androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
+extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
 memory = 6000


### PR DESCRIPTION
There is no need to request DHCP for Linux
kernel, since all configurations should be static, or
applied on the later boot stages.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>