### PR TITLE
doma: change start dependency to block

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/doma.bbappend
@@ -22,4 +22,5 @@ do_install_append() {
 
     install -d ${D}${sysconfdir}/systemd/system/doma.service.d
     install -m 0644 ${WORKDIR}/doma-set-root.conf ${D}${sysconfdir}/systemd/system/doma.service.d
+    install -m 0644 ${WORKDIR}/doma-start-dependency.conf ${D}${sysconfdir}/systemd/system/doma.service.d
 }

--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-start-dependency.conf
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-start-dependency.conf
@@ -1,0 +1,2 @@
+Requires=backend-ready@block.service
+After=backend-ready@block.service


### PR DESCRIPTION
In the current  product configuration, doma
should wait for a block device prior to start.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>