### PR TITLE
domd: add block dependency for block-up-notification

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
@@ -13,6 +13,7 @@ IMAGE_INSTALL_append = " \
     optee-os \
     fio \
     iotop \
+    block \
 "
 
 IMAGE_INSTALL_remove = " \


### PR DESCRIPTION
Since meta-xt-prod-cockpit-rcar uses core-image-minimal,
it should add block dependency to support block-up-notification
systemd service.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>