### PR TITLE
vis-service: fix build error of VisClient::getGearSelection

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-extended/vis-service/files/VisClient.cpp
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-extended/vis-service/files/VisClient.cpp
@@ -32,14 +32,6 @@ enum CtlIO_id{
     TURN = 4,
 };
 
-enum GearPosition{
-    PARK    	= 0,
-    NEUTRAL 	= 2,
-    DRIVE   	= 3,
-    REVERSE 	= 4,
-    GUNDEFINED 	= 5,
-};
-
 const int not_defined_value = std::numeric_limits<int>::max();
 
 typedef struct {
@@ -275,7 +267,7 @@ int VisClient::getSpeed(const QString &message)const
     return res == not_defined_value ? not_defined_value : (int)(res/1000);
 }
 
-GearPosition VisClient::getGearSelect(const QString & message)const
+VisClient::GearPosition VisClient::getGearSelect(const QString & message)const
 {
     int val = getValue("Signal.Drivetrain.Transmission.Gear", message);
     GearPosition res = GearPosition::GUNDEFINED;

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-extended/vis-service/files/VisClient.h
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-extended/vis-service/files/VisClient.h
@@ -41,9 +41,17 @@ private Q_SLOTS:
     void onSslErrors(const QList<QSslError> &errors);
     void onTextMessageReceived(const QString &message);
 
+private:
+    enum GearPosition{
+    	PARK        = 0,
+    	NEUTRAL     = 2,
+    	DRIVE       = 3,
+    	REVERSE     = 4,
+    	GUNDEFINED  = 5,
+    };
     QString getSubscriptionId(const QString &message)const;
     int getSpeed(const QString &message)const;
-    int getGearSelect(const QString &message)const;
+    GearPosition getGearSelect(const QString &message)const;
     int getRpm(const QString & message)const;
     int getTurnDirection(const QString & message)const;
     int getValue(const QString & propId, const QString & message)const;


### PR DESCRIPTION
The type of method in declaration and type in implementation were different. What was the reason of build error.
Fixed.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>