### PR TITLE
domd: remove dual-render-3d-part from build

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
@@ -1,6 +1,5 @@
 
 IMAGE_INSTALL_append = " \
-    dual-render-3d-part \
     xen \
     xen-tools-devd \
     xen-tools-scripts-network \


### PR DESCRIPTION
The service dual-render-3d-part is not used anymore.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>