### PR TITLE
Avoid resizing of console for SSH connections

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,6 @@
+do_install_append () {
+        echo "if [ -z $SSH_CONNECTION ]; then" >> ${D}${sysconfdir}/profile
+	echo "	shopt -s checkwinsize" >> ${D}${sysconfdir}/profile
+	echo "	resize 1> /dev/null" >> ${D}${sysconfdir}/profile
+	echo "fi" >> ${D}${sysconfdir}/profile
+}


### PR DESCRIPTION
We see that execution of 'resize' affects some applications during SSH connection. Also this command used only for interactive console.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>