### PR TITLE
cluster wrapper: set the source of branch CES-2023

### DIFF
--- a/meta-xt-prod-cockpit-rcar-cluster/recipes-cluster/cluster-bin/cluster-wrapper_git.bb
+++ b/meta-xt-prod-cockpit-rcar-cluster/recipes-cluster/cluster-bin/cluster-wrapper_git.bb
@@ -11,7 +11,7 @@ PLATFORM = "rcar"
 PARALLEL_MAKE = ""
 
 SRC_URI = " \
-   git://git@gitpct.epam.com/epmd-aepr/vlib;protocol=ssh;branch=sport-mode \
+   git://git@gitpct.epam.com/epmd-aepr/vlib;protocol=ssh;branch=CES-2023 \
 "
 
 SRCREV = "${AUTOREV}"


### PR DESCRIPTION
The branch has been renamed according to the business goal.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>