### PR TITLE
domd.cfg: Increase domain's memory to 768 MB

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-kf.cfg
@@ -10,7 +10,7 @@ device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
 extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=128M pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864 modprobe.blacklist=vsp2,vspm,vspm_if,uvcs_drv,mmngr,mmngrbuf"
 # Initial memory allocation (MB)
-memory = 512
+memory = 768
 # Number of VCPUS
 vcpus = 4
 on_crash = 'preserve'


### PR DESCRIPTION
The upcoming camera use-cases (with up to 4 cameras, resolution 1280x1080 being involved) will require some additional memory to allocate buffers for streaming.