### PR TITLE
camera: Introduce v4l2loopback driver

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
@@ -17,6 +17,7 @@ IMAGE_INSTALL_append = " \
     vis-service \
     cluster-view \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camerabe', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'v4l2loopback-mod', '', d)} \
 "
 
 IMAGE_INSTALL_remove = " \

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-kernel/v4l2loopback-mod/files/0001-makefile-Adapt-makefile-for-yocto-build.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-kernel/v4l2loopback-mod/files/0001-makefile-Adapt-makefile-for-yocto-build.patch
@@ -1,0 +1,41 @@
+From 4f1bbc019d34829d7306eaae6c0834cd3286273c Mon Sep 17 00:00:00 2001
+From: Mykyta Poturai <mykyta_poturai@epam.com>
+Date: Mon, 27 Mar 2023 13:09:13 +0000
+Subject: [PATCH] makefile: Adapt makefile for yocto build
+
+Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
+---
+ Makefile | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 1e8b433..84c5f3c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -40,11 +40,11 @@ all: v4l2loopback.ko
+ v4l2loopback: v4l2loopback.ko
+ v4l2loopback.ko:
+ 	@echo "Building v4l2-loopback driver..."
+-	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules
+ 
+ install-all: install install-utils install-man
+-install:
+-	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules_install
++modules_install:
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) modules_install
+ 	@echo ""
+ 	@echo "SUCCESS (if you got 'SSL errors' above, you can safely ignore them)"
+ 	@echo ""
+@@ -60,7 +60,7 @@ install-man: man/v4l2loopback-ctl.1
+ clean:
+ 	rm -f *~
+ 	rm -f Module.symvers Module.markers modules.order
+-	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) clean
++	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
+ 
+ distclean: clean
+ 	rm -f man/v4l2loopback-ctl.1
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-kernel/v4l2loopback-mod/v4l2loopback-mod_0.1.bb
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-kernel/v4l2loopback-mod/v4l2loopback-mod_0.1.bb
@@ -1,0 +1,22 @@
+SUMMARY = "v4l2loopback-module"
+DESCRIPTION = "Adds loopback v4l2 devices"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+SRCBRANCH = "main"
+
+inherit module
+
+SRC_URI = "git://github.com/umlaeute/v4l2loopback.git;protocol=https;branch=${SRCBRANCH} \
+	file://0001-makefile-Adapt-makefile-for-yocto-build.patch \
+"
+SRCREV = "1ecf810f0d687b647caa3050ae30cf51b5902afd"
+
+S = "${WORKDIR}/git"
+
+# The inherit of module.bbclass will automatically name module packages with
+# "kernel-module-" prefix as required by the oe-core build environment.
+
+EXTRA_OEMAKE += "-I${S}/usr/bin "
+FILESEXTRAPATHS_append := "${THISDIR}/files:"
+
+RPROVIDES_${PN} += "kernel-module-v4l2loopback"


### PR DESCRIPTION
The v4l2loopback driver is needed to share camera streams to multiple sinks at the same time.