### PR TITLE
domd/kernel: Enable CONFIG_MEDIA_XEN_FRONTEND

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-kernel/linux/files/defconfig
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-kernel/linux/files/defconfig
@@ -4426,7 +4426,7 @@ CONFIG_DVB_CXD2099=m
 CONFIG_DVB_SP2=m
 # end of Customise DVB Frontends
 
-# CONFIG_MEDIA_XEN_FRONTEND is not set
+CONFIG_MEDIA_XEN_FRONTEND=y
 # end of Media ancillary drivers
 
 #


### PR DESCRIPTION
Enable the PV camera frontend for shared video use-case. The idea is to share the stream from the same hardware device between two domains (DomD and DomA). In order to run the frontend in DomD we will need the hotplug support for PV camera since the backend is also in DomD.