### PR TITLE
doma-pvcamera.cfg: Assign all LVDS cameras

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-pvcamera.cfg
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-pvcamera.cfg
@@ -1,8 +1,8 @@
 
 # LVDS camera 0 configuration
-vcamera = [[ 'backend=DomD, be-alloc=0, unique-id=video0:media0, max-buffers=4',
-             'format=YUYV, resolution=1280x1080'
-          ]]
+# vcamera = [[ 'backend=DomD, be-alloc=0, unique-id=video0:media0, max-buffers=4',
+#              'format=YUYV, resolution=1280x1080'
+#           ]]
 
 # LVDS camera 1 configuration
 # vcamera = [[ 'backend=DomD, be-alloc=0, unique-id=video1:media0, max-buffers=4',
@@ -18,3 +18,17 @@ vcamera = [[ 'backend=DomD, be-alloc=0, unique-id=video0:media0, max-buffers=4',
 # vcamera = [[ 'backend=DomD, be-alloc=0, unique-id=video3:media0, max-buffers=4',
 #              'format=YUYV, resolution=1280x1080'
 #           ]]
+
+# LVDS cameras 0-3 (all cameras)
+vcamera = [[ 'backend=DomD, be-alloc=0, unique-id=video0:media0, max-buffers=4',
+             'format=BA24, resolution=1280x1080'
+           ],
+           [ 'backend=DomD, be-alloc=0, unique-id=video1:media0, max-buffers=4',
+              'format=BA24, resolution=1280x1080'
+           ],
+           [ 'backend=DomD, be-alloc=0, unique-id=video2:media0, max-buffers=4',
+              'format=BA24, resolution=1280x1080'
+           ],
+           [ 'backend=DomD, be-alloc=0, unique-id=video3:media0, max-buffers=4',
+              'format=BA24, resolution=1280x1080'
+           ]]


### PR DESCRIPTION
In order to use all of them in the guest.

Please note, the format "BA24" suits us better than "YUYV". DomD's counterpart should use the same format for the video sharing to work.