### PR TITLE
domd.cfg/doma.cfg: Rearrange RAM assigned to the guests

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-h3ulcb-4x2g-kf.cfg
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/doma/files/doma-h3ulcb-4x2g-kf.cfg
@@ -178,7 +178,7 @@ dt_passthrough_nodes = [
 extra = "androidboot.boot_devices=51712 androidboot.hardware=xenvm init=/init ro rootwait console=hvc0 androidboot.selinux=permissive pvrsrvkm.DriverMode=1 androidboot.android_dt_dir=/proc/device-tree/firmware#1/android/ xt_page_pool=2097152 xt_cma=4194304"
 
 # Initial memory allocation (MB)
-memory = 6000
+memory = 5000
 
 # Number of VCPUS
 vcpus = 4

--- a/meta-xt-prod-cockpit-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-kf.cfg
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-guests/domd/files/domd-h3ulcb-4x2g-kf.cfg
@@ -8,9 +8,9 @@ name = "DomD"
 kernel = "/usr/lib/xen/boot/linux-domd"
 device_tree = "/usr/lib/xen/boot/domd.dtb"
 # Kernel command line options
-extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=128M pvrsrvkm.DriverMode=0 xt_page_pool=33554432 xt_cma=67108864 modprobe.blacklist=vsp2,vspm,vspm_if,uvcs_drv,mmngr,mmngrbuf"
+extra = "root=/dev/STORAGE_PART2 rw rootwait console=hvc0 cma=256M pvrsrvkm.DriverMode=0 xt_page_pool=201326592 xt_cma=67108864 modprobe.blacklist=vsp2,vspm,vspm_if,uvcs_drv,mmngr,mmngrbuf"
 # Initial memory allocation (MB)
-memory = 512
+memory = 1536
 # Number of VCPUS
 vcpus = 4
 on_crash = 'preserve'


### PR DESCRIPTION
The upcoming camera use-cases (with up to 4 cameras per each guest and up to 4 buffers with resolution 1280x1080 per each camera being involved) will require some additional memory in DomD to allocate buffers for streaming as well as buffers for mapping guest pages into.

While increasing the whole Dom's memory (1536MB), increase also xt_page_pool (192MB) and cma (256MB) pools. Of course, in order to achieve that we have to borrow some memory from DomA.