### PR TITLE
domd/camera: Intergrate capture tool

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/capture_1.0.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/capture_1.0.bbappend
@@ -1,0 +1,21 @@
+S = "${WORKDIR}/git"
+
+SRC_URI = " git://github.com/renesas-rcar/capture.git;branch=rcar_gen4;protocol=https \
+	file://0001-Proccess-an-image-in-case-of-DRM-as-well-out_fb-is-n.patch \
+	file://0001-Change-default-camera-list.patch \
+	file://0002-Add-support-for-LVDS-cameras.patch \
+"
+
+SRCREV = "${AUTOREV}"
+
+
+
+DEPENDS = "libdrm"
+
+inherit pkgconfig
+
+
+
+do_populate_lic[noexec] = "1"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/files/0001-Change-default-camera-list.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/files/0001-Change-default-camera-list.patch
@@ -1,0 +1,29 @@
+From d405543aa27a79d27b4e0c9d5c91b31debead2dd Mon Sep 17 00:00:00 2001
+From: Mykyta Poturai <mykyta_poturai@epam.com>
+Date: Sat, 1 Apr 2023 11:35:43 +0000
+Subject: [PATCH 1/2] Change default camera list
+
+On cockpit product virtual cameras begin from /dev/video6, so change the
+default camerase from 0-3 to 6-9 when streaming multiple cameras.
+
+Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
+---
+ capture.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/capture.c b/capture.c
+index 71c2a4e..b36e1b7 100644
+--- a/capture.c
++++ b/capture.c
+@@ -75,7 +75,7 @@ static struct modeset_dev *modeset_list = NULL;
+ 
+ #define N_DEVS_MAX      12
+ static char             n_devs = 1;
+-static char            *dev_name[N_DEVS_MAX] = {"/dev/video0","/dev/video1","/dev/video2","/dev/video3","/dev/video4","/dev/video5","/dev/video6","/dev/video7","/dev/video8","/dev/video9","/dev/video10","/dev/video11"};
++static char            *dev_name[N_DEVS_MAX] = {"/dev/video6","/dev/video7","/dev/video8","/dev/video9","/dev/video4","/dev/video5","/dev/video6","/dev/video7","/dev/video8","/dev/video9","/dev/video10","/dev/video11"};
+ static char            *fbdev_name;
+ static enum io_method   io = IO_METHOD_MMAP;
+ //static enum io_method   io = IO_METHOD_USERPTR;
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/files/0001-Proccess-an-image-in-case-of-DRM-as-well-out_fb-is-n.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/files/0001-Proccess-an-image-in-case-of-DRM-as-well-out_fb-is-n.patch
@@ -1,0 +1,36 @@
+From 6e94f50a0f1c327b6150117512cc1ff18f31dfc9 Mon Sep 17 00:00:00 2001
+From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Date: Mon, 27 Mar 2023 20:52:07 +0300
+Subject: [PATCH] Proccess an image in case of DRM as well (out_fb is not set)
+
+It was checked with "rgb32" only.
+
+Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+---
+ capture.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/capture.c b/capture.c
+index 827a1f1..71c2a4e 100644
+--- a/capture.c
++++ b/capture.c
+@@ -169,7 +169,6 @@ static void process_image(const void *p, int size, int dev)
+         if (out_buf)
+                 fwrite(p, size, 1, stdout);
+ 
+-        if (out_fb) {
+             if (!strncmp(format_name, "rgb32", 5) | !strncmp(format_name, "raw10", 5)) {
+ 					int i;
+ 					int offset = (WIDTH*4)*(dev%(n_devs > 4 ? 4 : 2)) + (HEIGHT*modeset_list->stride)*(dev/(n_devs > 4 ? 4 : 2));
+@@ -244,7 +243,6 @@ static void process_image(const void *p, int size, int dev)
+             } else {
+                 fprintf(stderr, "format not supported to stream to Framebuffer\n");
+             }
+-        }
+ }
+ 
+ static int read_frame(int dev)
+-- 
+2.34.1
+
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/files/0002-Add-support-for-LVDS-cameras.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/capture/files/0002-Add-support-for-LVDS-cameras.patch
@@ -1,0 +1,66 @@
+From 0eae4c56dc22f56ff48a08d8c0161528089caed9 Mon Sep 17 00:00:00 2001
+From: Mykyta Poturai <mykyta_poturai@epam.com>
+Date: Sat, 1 Apr 2023 12:03:58 +0000
+Subject: [PATCH 2/2] Add support for LVDS cameras
+
+Add support for format specific converion between LVDS cameras and the
+LVDS display in DRM mode.
+
+When using pvcameras from multiple domains at the same time the
+streaming formats need to be the same. The closest one that android
+supports and we can process efficiently is ARGB32.
+
+Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
+---
+ capture.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/capture.c b/capture.c
+index b36e1b7..f288fe8 100644
+--- a/capture.c
++++ b/capture.c
+@@ -169,7 +169,19 @@ static void process_image(const void *p, int size, int dev)
+         if (out_buf)
+                 fwrite(p, size, 1, stdout);
+ 
+-            if (!strncmp(format_name, "rgb32", 5) | !strncmp(format_name, "raw10", 5)) {
++            if (!strncmp(format_name, "rgb32i", 6)){
++                int i;
++				int offset = (WIDTH*2)*(dev%(n_devs > 4 ? 4 : 3)) + (HEIGHT*modeset_list->stride/2)*(dev/(n_devs > 4 ? 4 : 3));
++				unsigned char *fbp = (unsigned char *)modeset_list->map + offset;
++				char *buf = (char *)p;
++
++				for (i = 0; i < HEIGHT; i+=2) {
++					memcpy(fbp, buf+1, WIDTH*2);
++					fbp += modeset_list->stride;
++					buf += (WIDTH*4);
++				}
++
++            } else if (!strncmp(format_name, "rgb32", 5) | !strncmp(format_name, "raw10", 5)) {
+ 					int i;
+ 					int offset = (WIDTH*4)*(dev%(n_devs > 4 ? 4 : 2)) + (HEIGHT*modeset_list->stride)*(dev/(n_devs > 4 ? 4 : 2));
+ 					unsigned char *fbp = (unsigned char *)modeset_list->map + offset;
+@@ -688,6 +700,11 @@ static void init_device(int dev)
+                 fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB565;
+                 output_fourcc = DRM_FORMAT_RGB565;
+         }
++        else if (!strncmp(format_name, "rgb32i", 5))
++        {
++                fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_ARGB32;
++                output_fourcc = DRM_FORMAT_XRGB8888;
++        }
+         else if (!strncmp(format_name, "rgb32", 5))
+         {
+                 fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_XBGR32;
+@@ -1135,7 +1152,7 @@ static void usage(FILE *fp, char **argv)
+                  "-u | --userp         Use application allocated buffers\n"
+                  "-o | --output        Outputs stream to stdout\n"
+                  "-F | --output_fb     Outputs stream to framebuffer\n"
+-                 "-f | --format        Set pixel format: raw10, uyvy, yuyv, rgb565, rgb32, nv12, nv16, bggr8, grey [%s]\n"
++                 "-f | --format        Set pixel format: raw10, uyvy, yuyv, rgb565, rgb32, rgb32i nv12, nv16, bggr8, grey [%s]\n"
+                  "-c | --count         Number of frames to grab [%i]\n"
+                  "-z | --fps_count     Enable fps show\n"
+                  "-s | --framerate     Set framerate\n"
+-- 
+2.25.1
+


### PR DESCRIPTION
Override the capture sources with newer one from Renesas. Add patches for DRM mode and virtual cameras support.

This tools is needed to show camera streams on a system without proper graphics environment.

Example launch command:
capture -d /dev/video6 -W 1280 -H 1080 -f rgb32i  -z -c 10000 -L 0 -T 0 -D 4