### PR TITLE
dom0: Move camera-hotplug under pvcamera distro feature

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -1,2 +1,2 @@
 IMAGE_INSTALL_append = " xen-tools-xenstat"
-IMAGE_INSTALL_append = " camera-hotplug"
+IMAGE_INSTALL_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camera-hotplug', '', d)}"


### PR DESCRIPTION
Camera hotplug makes no sense without pvcamera support, so make it dependent on the pvcamera feature.