### PR TITLE
domd, prebuild: add prebuilt graphic compinents

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Moulin is used to generate Ninja build file: moulin prod-cockpit-rcar.yaml. This
 
 ```
 # moulin prod-cockpit-rcar.yaml --help-config
-usage: moulin prod-cockpit-rcar.yaml --MACHINE h3ulcb-4x2g-kf --ENABLE_ANDROID yes --ENABLE_CLUSTER yes
+usage: moulin prod-cockpit-rcar.yaml --MACHINE h3ulcb-4x2g-kf --ENABLE_ANDROID yes --ENABLE_CLUSTER yes --PREBUILT_DDK no
        
 Config file description: Xen-Troops development setup for Renesas RCAR Gen3
 hardware
@@ -52,6 +52,8 @@ optional arguments:
                         Build Android as a guest VM
   --ENABLE_CLUSTER {no,yes}
                         Build Instrument Cluster application.
+  --PREBUILT_DDK {no,yes}
+                        Use pre-built GPU drivers
 
 ```
 

--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -15,6 +15,7 @@ variables:
   XT_OP_TEE_FLAVOUR: "generic_dt"
   XT_DOMA_TAG: ""
   XEN_URL: "git://git@gitpct.epam.com/rec-inv/xen.git;protocol=ssh;branch=v4.16rc_cr7"
+  XT_PREBUILT_GSX_DIR: ""
 
 common_data:
   # Sources used by all yocto-based domains
@@ -414,11 +415,25 @@ parameters:
   PREBUILT_DDK:
     desc: "Use pre-built GPU drivers"
     "no":
-      default: true
+      default: false
       overrides:
         components:
           domd:
             *DDK_SOURCE_OVERRIDES
+    "yes":
+      # Folder with prebuilt graphics package, i.e. file ${SOC_NAME}_linux_gsx_binaries_gles.tar.gz
+      # is provided as XT_PREBUILT_GSX_DIR variable to components
+      default: true
+      overrides:
+        variables:
+          XT_PREBUILT_GSX_DIR: "${TOPDIR}/../../prebuilt_gsx"
+        components:
+          domd:
+            builder:
+              conf:
+                - [XT_PREBUILT_GSX_DIR, "%{XT_PREBUILT_GSX_DIR}"]
+                - [FILESEXTRAPATHS_prepend_pn-gles-user-module, "%{XT_PREBUILT_GSX_DIR}:"]
+                - [FILESEXTRAPATHS_prepend_pn-kernel-module-gles, "%{XT_PREBUILT_GSX_DIR}:"]
 
   ENABLE_MM:
     desc: "Enable Multimedia support"


### PR DESCRIPTION
To activate the prebuild usage use the following in command line of mouline: PREBUILT_DDK yes