### PR TITLE
doma: change manifest repository to github based

### DIFF
--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -279,8 +279,8 @@ components:
     build-dir: "android"
     sources:
       - type: repo
-        url: "ssh://git@gitpct.epam.com/rec-inv/android_manifest.git"
-        rev: android-12-master
+        url: "git@github.com:xen-troops/android_manifest.git"
+        rev: android-12-prod-cockpit-rcar-master
         manifest: doma.xml
         depth: 1
         groups: "%{XT_DOMA_SOURCE_GROUP}"


### PR DESCRIPTION
Change manifest repository to github based, in terms of moving open projects to github.