### PR TITLE
prod-cockpit0rcar.yaml: fix revision of meta-aos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Usage: moulin prod-cockpit-rcar.yaml --MACHINE h3ulcb-4x2g-kf
                    [--ENABLE_CLUSTER yes]
 		   [--PREBUILT_DDK {no,yes}]
 		   [--ANDROID_PREBUILT_DDK {no,yes}]
-		   [--ENABLE_AOS_VIS {no, yes}]
+		   [--ENABLE_AOS {no, yes}]
        
 Config file description: Xen-Troops development setup for Renesas RCAR Gen3
 hardware
@@ -61,7 +61,7 @@ optional arguments:
                         Use pre-built GPU drivers. Default value is 'no'
   --ANDROID_PREBUILT_DDK {no,yes}
                         Use pre-built GPU drivers for Android. Default value is 'no'.
-  --ENABLE_AOS_VIS {no, yes}
+  --ENABLE_AOS {no, yes}
                         Use to add aos-vis functionality to the prodct, Default value is 'no'
 
 ```

--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -184,7 +184,7 @@ components:
         rev: "Renesas-Yocto-v5.1-patched"
       - type: git
         url: "https://github.com/aoscloud/meta-aos"
-        rev: "4b0f4ea629db039af8cec8f9ea019bb4c9e6d0c7"
+        rev: "402877ba01c789d458992a2b578a30830a5a35c1"
     builder:
       type: yocto
       work_dir: "%{DOMD_BUILD_DIR}"
@@ -604,9 +604,6 @@ parameters:
         components:
           domd:
             sources:
-              - type: git 
-                url: "https://github.com/aoscloud/meta-aos"
-                rev: main
               - type: git
                 url: "git://git.yoctoproject.org/meta-security"
                 rev: c62970fda82acf75035243766ecd195243e0f82a


### PR DESCRIPTION
The meta-aos had the reference at the branch 'main', what is not good for the fixed release.
Besides, the override for the ENABLE_AOS has been removed as unnecessary.