### PR TITLE
prod-cockpit-rcar.yaml, doma: remove notdefault group

### DIFF
--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -583,7 +583,7 @@ parameters:
       overrides:
         variables:
           XT_DOMA_DDK_KM_PREBUILT_MODULE: "eva/pvr-km/pvrsrvkm.ko"
-          XT_DOMA_SOURCE_GROUP: "default,notdefault"
+          XT_DOMA_SOURCE_GROUP: "default"
         components:
           doma:
             sources:


### PR DESCRIPTION
Now, all required packages are placed under 'default' packages. The notdefault is not necessary