### PR TITLE
yaml: introduce XT_DOMA_KERNEL_BUILD_CONFIG variable

### DIFF
--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -17,6 +17,7 @@ variables:
   XEN_URL: "git://git@gitpct.epam.com/rec-inv/xen.git;protocol=ssh;branch=v4.16rc_cr7"
   XT_PREBUILT_GSX_DIR: ""
   XT_DOMA_DDK_KM_PREBUILT_MODULE: ""
+  XT_DOMA_KERNEL_BUILD_CONFIG: "build.config.xenvm"
   XT_DOMA_SOURCE_GROUP: ""  
 
 common_data:
@@ -264,7 +265,7 @@ components:
       type: android_kernel
       env:
         - "TARGET_BOARD_PLATFORM=%{SOC_FAMILY}"
-        - "BUILD_CONFIG=common/build.config.xenvm"
+        - "BUILD_CONFIG=common/%{XT_DOMA_KERNEL_BUILD_CONFIG}"
         - "SKIP_MRPROPER=1"
       target_images:
         - "out/android12-5.4/dist/Image"
@@ -584,6 +585,7 @@ parameters:
         variables:
           XT_DOMA_DDK_KM_PREBUILT_MODULE: "eva/pvr-km/pvrsrvkm.ko"
           XT_DOMA_SOURCE_GROUP: "default"
+          XT_DOMA_KERNEL_BUILD_CONFIG: "build.config.xenvm.no_graphics"
         components:
           doma:
             sources:


### PR DESCRIPTION
Introduce the XT_DOMA_KERNEL_BUILD_CONFIG variable, which allows for the selection of different kernel configurations based on specific use cases. This variable provides the flexibility to choose the appropriate kernel configuration depending on the requirements of each use case.
For instance, when opting for prebuilts, the kernel configuration can be adjusted to include fewer modules.