### PR TITLE
prod-cockpit-rcar, doma_kernel: usage doma groups.

### DIFF
--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -259,7 +259,7 @@ components:
         rev: common-android12-5.4-cr7-master
         manifest: default.xml
         depth: 1
-        groups: all
+        groups: "%{XT_DOMA_SOURCE_GROUP}"
         dir: "."
     builder:
       type: android_kernel


### PR DESCRIPTION
It allows using the same configuration groups to reduce the number of errors.