### PR TITLE
domd: update branch for bmap-tools

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
@@ -1,0 +1,3 @@
+# Intel renamed 'master' branch to 'main' so we
+# have to overwrite SRC_URI with proper branch
+SRC_URI = "git://github.com/intel/${BPN};branch=main;protocol=https"


### PR DESCRIPTION
Intel renamed 'master' branch to 'main' so we
have to overwrite SRC_URI accordingly.