### PR TITLE
metadata.json: change the name of the component

### DIFF
--- a/scripts/ic-update/metadata.json
+++ b/scripts/ic-update/metadata.json
@@ -2,9 +2,9 @@
     "formatVersion": 1,
     "components": [
         {
-            "id": "h3ulcb-4x2g-ab-1.0-cluster",
+            "id": "rcar-multinode-zephyr-1.0-spider-cluster",
             "fileName": "update-mode.tar.bz2",
-            "vendorVersion": "0.0.42",
+            "vendorVersion": "0.0.8",
             "description": "Update IC mode"
         }
     ]


### PR DESCRIPTION
The component name has been changed according to the name of the component at aosadge.(see https://oem.aoscloud.io/oem/systems, name 'rcar-multinode-zephyr')