### PR TITLE
atf, i2c: add scmi-clock.

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -9,6 +9,17 @@ SRC_URI_r8a7796_append = "\
 SRC_URI_append = "\
     file://0002-Change-the-security-attribute-setting-for-Cortex-R7.patch \
     file://0003-Kick_CR7_in_bl2.patch \
+    file://0003-Add-bldcmd.sh.patch \
+    file://0005-rcar-Add-DRAM2_NS_SCMI-memory-region-to-BL31-mapping.patch \
+    file://0006-rcar-add-SCMI-reset-protocol-implementation.patch \
+    file://0007-rcar-add-SCMI-clock-protocol-implementation.patch \
+    file://0008-rcar-add-SCMI-stub-power-protocol-implementation.patch \
+    file://0008-sip_sv-rollback-the-service-to-support-scmi.patch \
+    file://0009-rcar-SCMI-base-protocol-implementation-and-handling.patch \
+    file://0010-rcar-scmi-add-physical-resources-to-SCMI-devices.patch \
+    file://0011-bldcmd.sh-build-scmi-platform-by-default.patch \
+    file://0001-rcar_scmi_clocks.c-fix-build-error-no-returned-value.patch \
+    file://0001-scmi-i2c-add-scmi-clock-to-i2c2.patch \
 "
 
 # This patch is required for CR7 on H3. Strictly speaking it is needed only

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-plat-renesas-rcar-bl31-Enable-RPC-access-if-necessar.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-plat-renesas-rcar-bl31-Enable-RPC-access-if-necessar.patch
@@ -1,0 +1,35 @@
+From 1f90112f00a0b831a24c38e242e6b8d191a262e7 Mon Sep 17 00:00:00 2001
+From: Valentine Barshak <valentine.barshak@cogentembedded.com>
+Date: Thu, 11 Feb 2021 20:15:02 +0300
+Subject: [PATCH 01/11] plat: renesas: rcar: bl31: Enable RPC access if
+ necessary
+
+This enables RPC flash access before leaving BL31
+in case RCAR_RPC_HYPERFLASH_LOCKED is disabled.
+
+Signed-off-by: Valentine Barshak <valentine.barshak@cogentembedded.com>
+---
+ plat/renesas/rcar/bl31_plat_setup.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/plat/renesas/rcar/bl31_plat_setup.c b/plat/renesas/rcar/bl31_plat_setup.c
+index 8dd3a5fef..c1ec987e0 100644
+--- a/plat/renesas/rcar/bl31_plat_setup.c
++++ b/plat/renesas/rcar/bl31_plat_setup.c
+@@ -141,3 +141,13 @@ uint32_t bl31_plat_boot_mpidr_chk(void)
+ 	return rc;
+ }
+ 
++void bl31_plat_runtime_setup(void)
++{
++#if (RCAR_RPC_HYPERFLASH_LOCKED == 0)
++	/* Enable non-secure access to the RPC HyperFlash region. */
++	mmio_write_32(0xee2000b8, 0x155);
++	mmio_write_32(0xee200000, mmio_read_32(0xee200000) & 0x7fffffff);
++#endif
++
++	console_switch_state(CONSOLE_FLAG_RUNTIME);
++}
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-rcar_scmi_clocks.c-fix-build-error-no-returned-value.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-rcar_scmi_clocks.c-fix-build-error-no-returned-value.patch
@@ -1,0 +1,25 @@
+From caa440d9943df11c241a7550ba32298d84c1e2ce Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 17:18:23 +0200
+Subject: [PATCH 12/12] rcar_scmi_clocks.c: fix build error 'no returned value'
+
+Signed-off-by: Ihor Usyk <ihor.usyk@gmail.com>
+---
+ plat/renesas/rcar/rcar_scmi_clocks.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/plat/renesas/rcar/rcar_scmi_clocks.c b/plat/renesas/rcar/rcar_scmi_clocks.c
+index 0b2b92908..51b52de6d 100644
+--- a/plat/renesas/rcar/rcar_scmi_clocks.c
++++ b/plat/renesas/rcar/rcar_scmi_clocks.c
+@@ -758,6 +758,7 @@ static const struct scmi_clk_ops * __clk_get_ops(struct scmi_clk *sclk)
+        }
+ 
+        /* should not reach here */
++       return NULL;
+ }
+ 
+ static uint64_t __clk_get_rate_locked(uint32_t id)
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-scmi-i2c-add-scmi-clock-to-i2c2.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0001-scmi-i2c-add-scmi-clock-to-i2c2.patch
@@ -1,0 +1,79 @@
+From c3697bf4498c11ca79ecf877e73288b9c3da7b74 Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 24 Jul 2023 22:53:16 +0200
+Subject: [PATCH] scmi, i2c: add scmi clock to i2c2
+
+Motivation is to support scmi clock for success doma restart.
+
+Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>
+---
+ plat/renesas/common/include/rcar_scmi_resources.h |  1 +
+ plat/renesas/rcar/rcar_scmi_clocks.c              | 13 +++++++++++++
+ plat/renesas/rcar/rcar_scmi_devices.c             |  2 +-
+ 3 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/plat/renesas/common/include/rcar_scmi_resources.h b/plat/renesas/common/include/rcar_scmi_resources.h
+index d31fe2dc0..455cd072c 100644
+--- a/plat/renesas/common/include/rcar_scmi_resources.h
++++ b/plat/renesas/common/include/rcar_scmi_resources.h
+@@ -129,6 +129,7 @@ enum rcar_scmi_clk {
+ 	RCAR_SCMICLK_SCU_SRC0,	/* 34 */
+ 	RCAR_SCMICLK_AUDMAC1,	/* 35 */
+ 	RCAR_SCMICLK_AUDMAC0,	/* 36 */
++	RCAR_SCMICLK_I2C2,
+ 	RCAR_SCMICLK_HDMI,
+ 	RCAR_SCMICLK_HDMI0,
+ 	RCAR_SCMICLK_HDMI1,
+diff --git a/plat/renesas/rcar/rcar_scmi_clocks.c b/plat/renesas/rcar/rcar_scmi_clocks.c
+index 51b52de6d..583e77ba6 100644
+--- a/plat/renesas/rcar/rcar_scmi_clocks.c
++++ b/plat/renesas/rcar/rcar_scmi_clocks.c
+@@ -40,12 +40,14 @@
+ #define SMSTPCR5  0x144
+ #define SMSTPCR7  0x14C
+ #define SMSTPCR8  0x990
++#define SMSTPCR9  0x994
+ #define SMSTPCR10 0x998
+ 
+ #define MSTPSR3  0x048
+ #define MSTPSR5  0x03C
+ #define MSTPSR7  0x1C4
+ #define MSTPSR8  0x9A0
++#define MSTPSR9  0x9A4
+ #define MSTPSR10 0x9A8
+ 
+ enum scmi_message_id {
+@@ -491,6 +493,17 @@ struct scmi_clk rcar_clocks[RCAR_CLK_MAX] = {
+ 			.init = MSSR_OFF,
+ 		}
+ 	},
++	[RCAR_SCMICLK_I2C2] = {
++                .name = "_i2c2",
++                .parent = RCAR_CLK_S3D2,
++                .type = CLK_TYPE_MSSR,
++                .clk.mssr = {
++                         .cr = SMSTPCR9,
++                        .st = MSTPSR9, 
++                        .bit = 29,
++                        .init = MSSR_OFF,
++               } 
++        },
+ 	[RCAR_SCMICLK_HDMI] = {
+ 		.name = "_hdmi",
+ 		.parent = -1, /*TODO: div6 clocks support */
+diff --git a/plat/renesas/rcar/rcar_scmi_devices.c b/plat/renesas/rcar/rcar_scmi_devices.c
+index 93cc7d197..9bdfc7cd0 100644
+--- a/plat/renesas/rcar/rcar_scmi_devices.c
++++ b/plat/renesas/rcar/rcar_scmi_devices.c
+@@ -61,7 +61,7 @@ const struct scmi_device rcar_devices[RCAR_SCMIDEV_MAX] = {
+ 	},
+ 	[RCAR_SCMIDEV_I2C2] = {
+ 		.rsts = (int[]){RCAR_SCMIRST_I2C2,-1},
+-		.clks = (int[]){-1},
++		.clks = (int[]){RCAR_SCMICLK_I2C2,-1},
+ 	},
+ 	[RCAR_SCMIDEV_I2C3] = {
+ 		.rsts = (int[]){RCAR_SCMIRST_I2C3,-1},
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0002-tools-Produce-two-cert_header_sa6-images.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0002-tools-Produce-two-cert_header_sa6-images.patch
@@ -1,0 +1,83 @@
+From 8e5ab4066f87437bed7402f8f283cd2b7775815a Mon Sep 17 00:00:00 2001
+From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Date: Tue, 2 Feb 2021 18:42:36 +0200
+Subject: [PATCH 02/11] tools: Produce two cert_header_sa6 images
+
+An already existed image is used to boot SoC from the Hyperflash,
+while the newly created image (cert_header_sa6_emmc) is needed to boot
+SoC from EMMC boot partition 1.
+For producing suitable for "eMMC boot" image we have to build sa6.c
+source file again, but with RCAR_SA6_TYPE flag being forced to 1.
+
+Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>
+---
+ tools/renesas/rcar_layout_create/makefile | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/tools/renesas/rcar_layout_create/makefile b/tools/renesas/rcar_layout_create/makefile
+index 4bfea7dc6..0577e396a 100644
+--- a/tools/renesas/rcar_layout_create/makefile
++++ b/tools/renesas/rcar_layout_create/makefile
+@@ -11,18 +11,26 @@
+ #output file name
+ FILE_NAME_SA0   = bootparam_sa0
+ FILE_NAME_SA6   = cert_header_sa6
++FILE_NAME_SA6_EMMC = cert_header_sa6_emmc
+ 
+ OUTPUT_FILE_SA0 = $(FILE_NAME_SA0).elf
+ OUTPUT_FILE_SA6 = $(FILE_NAME_SA6).elf
++OUTPUT_FILE_SA6_EMMC = $(FILE_NAME_SA6_EMMC).elf
+ 
+ #object file name
+ OBJ_FILE_SA0 =	sa0.o
+ OBJ_FILE_SA6 =	sa6.o
++OBJ_FILE_SA6_EMMC =	sa6_emmc.o
+ 
+ #linker script name
+ MEMORY_DEF_SA0 = sa0.ld.S
+ MEMORY_DEF_SA6 = sa6.ld.S
+ 
++# source file name
++SOURCE_FILE_SA6 =	sa6.c
++# Explicitly set RCAR_SA6_TYPE flag
++CFLAGS_SA6_EMMC = `echo "${CFLAGS}" | sed -e 's/-DRCAR_SA6_TYPE=0/-DRCAR_SA6_TYPE=1/'`
++
+ ###################################################
+ # Convenience function for adding build definitions
+ # $(eval $(call add_define,FOO)) will have:
+@@ -89,7 +97,7 @@ CL = rm -f
+ # command
+ 
+ .PHONY: all
+-all: $(OUTPUT_FILE_SA0) $(OUTPUT_FILE_SA6)
++all: $(OUTPUT_FILE_SA0) $(OUTPUT_FILE_SA6) $(OUTPUT_FILE_SA6_EMMC)
+ ###################################################
+ # Linker
+ ###################################################
+@@ -111,10 +119,22 @@ $(OUTPUT_FILE_SA6) : $(MEMORY_DEF_SA6) $(OBJ_FILE_SA6)
+ 	$(objcopy) -O srec --adjust-vma=$(RCAR_VMA_ADJUST_ADDR) --srec-forceS3  $(OUTPUT_FILE_SA6) $(FILE_NAME_SA6).srec
+ 	$(objcopy) -O binary --adjust-vma=$(RCAR_VMA_ADJUST_ADDR) --srec-forceS3  $(OUTPUT_FILE_SA6) $(FILE_NAME_SA6).bin
+ 
++$(OUTPUT_FILE_SA6_EMMC) : $(MEMORY_DEF_SA6) $(OBJ_FILE_SA6_EMMC)
++	$(LD) $(OBJ_FILE_SA6_EMMC)      \
++	-T $(MEMORY_DEF_SA6)            \
++	-o $(OUTPUT_FILE_SA6_EMMC)      \
++	-Map $(FILE_NAME_SA6_EMMC).map  \
++
++	$(objcopy) -O srec --adjust-vma=0xE6320000 --srec-forceS3  $(OUTPUT_FILE_SA6_EMMC) $(FILE_NAME_SA6_EMMC).srec
++	$(objcopy) -O binary --adjust-vma=0xE6320000 --srec-forceS3  $(OUTPUT_FILE_SA6_EMMC) $(FILE_NAME_SA6_EMMC).bin
++
+ ###################################################
+ # Compile
+ ###################################################
+ 
++$(OBJ_FILE_SA6_EMMC):$(SOURCE_FILE_SA6)
++	${CC} -c ${CFLAGS_SA6_EMMC} ${CPPFLAGS} $< -o $@
++
+ %.o:../%.c
+ 	$(CC) -c -I $< -o $@
+ 
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0003-Add-bldcmd.sh.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0003-Add-bldcmd.sh.patch
@@ -1,0 +1,37 @@
+From 66c2d5a77e00ed07ff895bc55f3e297d0fb94599 Mon Sep 17 00:00:00 2001
+From: Sergiy Kibrik <sakib@darkstar.site>
+Date: Fri, 14 May 2021 12:14:59 +0000
+Subject: [PATCH 03/11] Add bldcmd.sh
+
+---
+ bldcmd.sh | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+ create mode 100644 bldcmd.sh
+
+diff --git a/bldcmd.sh b/bldcmd.sh
+new file mode 100644
+index 000000000..ec0bc44cf
+--- /dev/null
++++ b/bldcmd.sh
+@@ -0,0 +1,18 @@
++make -j17 \
++ARCH=aarch64 \
++CROSS_COMPILE=aarch64-linux-gnu- \
++CC=aarch64-linux-gnu-gcc \
++PLAT=rcar \
++MBEDTLS_COMMON_MK=1 \
++LSI=H3 \
++LOG_LEVEL=40 \
++RCAR_DRAM_SPLIT=1 \
++RCAR_GEN3_ULCB=1 \
++PMIC_LEVEL_MODE=0 \
++RCAR_DRAM_LPDDR4_MEMCONF=1 \
++RCAR_LOSSY_ENABLE=1 \
++RCAR_BL33_EXECUTION_EL=1  \
++RCAR_RPC_HYPERFLASH_LOCKED=0 \
++DEBUG=1 \
++SPD=opteed \
++bl2 bl31 rcar
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0005-rcar-Add-DRAM2_NS_SCMI-memory-region-to-BL31-mapping.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0005-rcar-Add-DRAM2_NS_SCMI-memory-region-to-BL31-mapping.patch
@@ -1,0 +1,68 @@
+From 292df2863c42f188d7daa2d74cb44b028da1159b Mon Sep 17 00:00:00 2001
+From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Date: Fri, 29 Sep 2017 13:56:04 +0300
+Subject: [PATCH 04/12] rcar: Add DRAM2_NS_SCMI memory region to BL31 mapping
+
+Actually it is shared memory region owned by Secure World DDR area
+for communication between server (ARM TF) and client (some software
+running in lower privilege level) using SCMI protocol.
+
+Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+---
+ plat/renesas/common/aarch64/platform_common.c | 4 ++++
+ plat/renesas/common/include/platform_def.h    | 2 +-
+ plat/renesas/common/include/rcar_def.h        | 2 ++
+ 3 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/plat/renesas/common/aarch64/platform_common.c b/plat/renesas/common/aarch64/platform_common.c
+index 22660166f..dc2253189 100644
+--- a/plat/renesas/common/aarch64/platform_common.c
++++ b/plat/renesas/common/aarch64/platform_common.c
+@@ -39,6 +39,9 @@ const uint8_t version_of_renesas[VERSION_OF_RENESAS_MAXLEN]
+ #define MAP_SHARED_RAM		MAP_REGION_FLAT(RCAR_SHARED_MEM_BASE,	\
+ 					RCAR_SHARED_MEM_SIZE,		\
+ 					MT_MEMORY | MT_RW | MT_SECURE)
++#define MAP_DRAM2_NS_SCMI	MAP_REGION_FLAT(DRAM2_NS_SCMI_BASE,	\
++					DRAM2_NS_SCMI_SIZE,		\
++					MT_RW_DATA | MT_NS)
+ 
+ #define MAP_FLASH0		MAP_REGION_FLAT(FLASH0_BASE,		\
+ 					FLASH0_SIZE,			\
+@@ -126,6 +129,7 @@ static const mmap_region_t rcar_mmap[] = {
+ 	MAP_SHARED_RAM,
+ 	MAP_ATFW_CRASH,
+ 	MAP_ATFW_LOG,
++	MAP_DRAM2_NS_SCMI,
+ 	MAP_DEVICE_RCAR,
+ 	MAP_DEVICE_RCAR2,
+ 	MAP_SRAM,
+diff --git a/plat/renesas/common/include/platform_def.h b/plat/renesas/common/include/platform_def.h
+index e86e0cac4..7e2a4a3a5 100644
+--- a/plat/renesas/common/include/platform_def.h
++++ b/plat/renesas/common/include/platform_def.h
+@@ -161,7 +161,7 @@
+ #elif IMAGE_BL2
+ #define MAX_XLAT_TABLES		U(5)
+ #elif IMAGE_BL31
+-#define MAX_XLAT_TABLES		U(4)
++#define MAX_XLAT_TABLES		U(5)
+ #elif IMAGE_BL32
+ #define MAX_XLAT_TABLES		U(3)
+ #endif
+diff --git a/plat/renesas/common/include/rcar_def.h b/plat/renesas/common/include/rcar_def.h
+index 38706a837..0b91595e5 100644
+--- a/plat/renesas/common/include/rcar_def.h
++++ b/plat/renesas/common/include/rcar_def.h
+@@ -20,6 +20,8 @@
+ #define FLASH0_SIZE			U(0x04000000)
+ #define FLASH_MEMORY_SIZE		U(0x04000000)	/* hyper flash */
+ #define FLASH_TRANS_SIZE_UNIT		U(0x00000100)
++#define DRAM2_NS_SCMI_BASE		U(0x57000000)
++#define DRAM2_NS_SCMI_SIZE		U(0x00010000)
+ #define DEVICE_RCAR_BASE		U(0xE6000000)
+ #define DEVICE_RCAR_SIZE		U(0x00300000)
+ #define DEVICE_RCAR_BASE2		U(0xE6360000)
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0006-rcar-add-SCMI-reset-protocol-implementation.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0006-rcar-add-SCMI-reset-protocol-implementation.patch
@@ -1,0 +1,384 @@
+From 488b537362f7c17134067cae4813ee5cccb9af1b Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 14:01:38 +0200
+Subject: [PATCH 05/12] rcar: add SCMI reset protocol implementation
+
+Will be used in ATF SCP implementation.
+
+Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+---
+ plat/renesas/common/include/rcar_private.h    |  40 +++
+ .../common/include/rcar_scmi_resources.h      |  40 +++
+ plat/renesas/rcar/platform.mk                 |   3 +-
+ plat/renesas/rcar/rcar_scmi_reset.c           | 239 ++++++++++++++++++
+ 4 files changed, 321 insertions(+), 1 deletion(-)
+ create mode 100644 plat/renesas/common/include/rcar_scmi_resources.h
+ create mode 100644 plat/renesas/rcar/rcar_scmi_reset.c
+
+diff --git a/plat/renesas/common/include/rcar_private.h b/plat/renesas/common/include/rcar_private.h
+index 36f4ca540..feed21c3a 100644
+--- a/plat/renesas/common/include/rcar_private.h
++++ b/plat/renesas/common/include/rcar_private.h
+@@ -7,9 +7,11 @@
+ #ifndef RCAR_PRIVATE_H
+ #define RCAR_PRIVATE_H
+ 
++#include <assert.h>
+ #include <common/bl_common.h>
+ #include <lib/bakery_lock.h>
+ #include <lib/el3_runtime/cpu_data.h>
++#include <lib/xlat_tables/xlat_tables_defs.h>
+ 
+ #include <platform_def.h>
+ 
+@@ -105,4 +107,42 @@ void rcar_console_boot_end(void);
+ void rcar_console_runtime_init(void);
+ void rcar_console_runtime_end(void);
+ 
++#define SCMI_SUCCESS           0
++#define SCMI_NOT_SUPPORTED     (-1)
++#define SCMI_INVALID_PARAMETERS        (-2)
++#define SCMI_DENIED            (-3)
++#define SCMI_NOT_FOUND         (-4)
++#define SCMI_OUT_OF_RANGE      (-5)
++#define SCMI_BUSY              (-6)
++#define SCMI_COMMS_ERROR       (-7)
++#define SCMI_GENERIC_ERROR     (-8)
++#define SCMI_HARDWARE_ERROR    (-9)
++#define SCMI_PROTOCOL_ERROR    (-10)
++
++#define RCAR_SCMI_CHAN_COUNT   (DRAM2_NS_SCMI_SIZE & ~(PAGE_SIZE - 1)) / PAGE_SIZE
++#define SCMI_PROTOCOL_VERSION  0x20000 /* DEN0056C, 4.2.2.1 */
++
++#define FLD(mask, val) (((val) << (__builtin_ffsll(mask) - 1) & (mask)))
++#define FLD_GET(mask, val) (((val) & (mask)) >> (__builtin_ffsll(mask) - 1))
++
++typedef uint16_t scmi_perm_t;
++
++_Static_assert(sizeof(scmi_perm_t) * 8 == RCAR_SCMI_CHAN_COUNT);
++
++struct scmi_reset {
++       uint16_t rst_reg;
++       uint16_t clr_reg;
++       uint8_t bit_off;
++       scmi_perm_t perm;
++};
++
++static inline bool scmi_permission_granted(scmi_perm_t perm, uint32_t channel)
++{
++       assert(channel < RCAR_SCMI_CHAN_COUNT);
++       return perm & (1 << channel);
++}
++
++uint32_t rcar_scmi_handle_reset(size_t, uint8_t, volatile uint8_t*, size_t);
++void rcar_reset_reset(uint32_t);
++
+ #endif /* RCAR_PRIVATE_H */
+diff --git a/plat/renesas/common/include/rcar_scmi_resources.h b/plat/renesas/common/include/rcar_scmi_resources.h
+new file mode 100644
+index 000000000..f001788e0
+--- /dev/null
++++ b/plat/renesas/common/include/rcar_scmi_resources.h
+@@ -0,0 +1,40 @@
++/*
++ * Copyright (c) 2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution. 
++ * 
++ * Neither the name of ARM nor the names of its contributors may be used 
++ * to endorse or promote products derived from this software without specific 
++ * prior written permission. 
++ * 
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
++ * POSSIBILITY OF SUCH DAMAGE.                                                                       
++ */                                                                                                  
++
++#ifndef RCAR_SCMI_RESOURCES_H
++#define RCAR_SCMI_RESOURCES_H
++
++enum rcar_scmi_rst_offset {
++       RCAR_SCMIRST_MAX
++};
++
++extern struct scmi_reset rcar_resets[RCAR_SCMIRST_MAX];
++
++#endif /* RCAR_SCMI_RESOURCES_H */
+diff --git a/plat/renesas/rcar/platform.mk b/plat/renesas/rcar/platform.mk
+index 7c90b8a8a..93fbd0d84 100644
+--- a/plat/renesas/rcar/platform.mk
++++ b/plat/renesas/rcar/platform.mk
+@@ -330,7 +330,8 @@ BL31_CFLAGS	+=	-fno-stack-protector
+ endif
+ 
+ ifeq (${RCAR_GEN3_ULCB},1)
+-BL31_SOURCES		+=	drivers/renesas/rcar/cpld/ulcb_cpld.c
++BL31_SOURCES		+=	drivers/renesas/rcar/cpld/ulcb_cpld.c \
++				plat/renesas/rcar/rcar_scmi_reset.c
+ endif
+ 
+ # build the layout images for the bootrom and the necessary srecords
+diff --git a/plat/renesas/rcar/rcar_scmi_reset.c b/plat/renesas/rcar/rcar_scmi_reset.c
+new file mode 100644
+index 000000000..9947207e6
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_scmi_reset.c
+@@ -0,0 +1,239 @@
++/*
++ * Copyright (c) 2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * Neither the name of ARM nor the names of its contributors may be used
++ * to endorse or promote products derived from this software without specific
++ * prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <assert.h>
++#include <lib/mmio.h>
++
++#include "micro_delay.h"
++#include "rcar_private.h"
++#include "rcar_scmi_resources.h"
++
++#define CPG_BASE U(0xE6150000)
++
++struct scmi_reset rcar_resets[RCAR_SCMIRST_MAX] = {
++};
++
++enum scmi_message_id {
++       PROTOCOL_VERSION = 0x0,
++       PROTOCOL_ATTRIBUTES,
++       PROTOCOL_MESSAGE_ATTRIBUTES,
++       RESET_DOMAIN_ATTRIBUTES,
++       RESET,
++       RESET_NOTIFY,
++       SCMI_LAST_ID
++};
++
++static void rcar_assert_domain(uint32_t domain)
++{
++       assert(domain < ARRAY_SIZE(rcar_resets));
++       mmio_write_32(CPG_BASE + rcar_resets[domain].rst_reg,
++                     BIT(rcar_resets[domain].bit_off));
++}
++
++static void rcar_deassert_domain(uint32_t domain)
++{
++       assert(domain < ARRAY_SIZE(rcar_resets));
++       mmio_write_32(CPG_BASE + rcar_resets[domain].clr_reg,
++                     BIT(rcar_resets[domain].bit_off));
++}
++
++static void rcar_auto_domain(uint32_t domain)
++{
++       rcar_assert_domain(domain);
++       rcar_micro_delay(35);
++       rcar_deassert_domain(domain);
++}
++
++static uint32_t protocol_version(size_t channel __unused,
++                                volatile uint8_t *param,
++                                size_t size __unused)
++{
++       int32_t *status = (int32_t*)param;
++       uint32_t *version = (uint32_t*)(param + sizeof(*status));
++       *status = SCMI_SUCCESS;
++       *version = SCMI_PROTOCOL_VERSION;
++       return sizeof(*status) + sizeof(*version);
++}
++
++static uint32_t protocol_attrs(size_t channel __unused,
++                              volatile uint8_t *param,
++                              size_t size __unused)
++{
++       int32_t *status = (int32_t*)param;
++       uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++
++       *status = SCMI_SUCCESS;
++       *attrs = FLD(GENMASK(31, 16), 0) |
++                FLD(GENMASK(15,  0), RCAR_SCMIRST_MAX);
++
++       return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t protocol_msg_attrs(size_t channel __unused,
++                                  volatile uint8_t *param,
++                                  size_t size)
++{
++       uint32_t id = *(uint32_t*)param;
++       int32_t *status = (int32_t*)param;
++       uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++
++       if (size != sizeof(id)) {
++               *status = SCMI_PROTOCOL_ERROR;
++               return sizeof(*status);
++       }
++
++       /* RESET_NOTIFY not supported in synchronous SCP implementation */
++       if (id == RESET_NOTIFY) {
++               *status = SCMI_NOT_FOUND;
++       } else {
++               *status = SCMI_SUCCESS;
++       }
++
++       *attrs = 0x0;
++
++       return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t reset_attrs(size_t channel __unused,
++                           volatile uint8_t *param,
++                           size_t size)
++{
++       struct rst_discovery {
++               int32_t status;
++               uint32_t attributes;
++               uint32_t latency;
++               char name[16];
++       } *res = (struct rst_discovery*)param;
++       uint32_t domain_id = *(uint32_t*)param;
++
++       if (size != sizeof(domain_id)) {
++               res->status = SCMI_PROTOCOL_ERROR;
++               return sizeof(res->status);
++       }
++
++       if (domain_id >= RCAR_SCMIRST_MAX) {
++               res->status = SCMI_NOT_FOUND;
++               return sizeof(res->status);
++       }
++
++       memset(res->name, 0, sizeof(res->name));
++
++       /* synchronous SCP implementation */
++       res->attributes = 0;
++       res->latency = 0xFFFFFFFF;
++
++       res->status = SCMI_SUCCESS;
++
++       return sizeof(*res);
++}
++
++static uint32_t reset(size_t channel,
++                     volatile uint8_t *payload,
++                     size_t size)
++{
++       struct parameters {
++               uint32_t id;
++               uint32_t flags;
++               uint32_t state;
++       } param = *((struct parameters*)payload);
++       int32_t status;
++
++       if (size != sizeof(param)) {
++               status = SCMI_PROTOCOL_ERROR;
++               goto error;
++       }
++
++       if (param.id >= RCAR_SCMIRST_MAX) {
++               status = SCMI_NOT_FOUND;
++               goto error;
++       }
++
++       if (param.flags & GENMASK(31,2)) {
++               /* synchronous SCP implementation */
++               status = SCMI_INVALID_PARAMETERS;
++               goto error;
++       }
++
++       if (!scmi_permission_granted(rcar_resets[param.id].perm, channel)) {
++               status = SCMI_DENIED;
++               goto error;
++       }
++
++       if (param.flags & BIT(0)) {
++               rcar_auto_domain(param.id);
++       } else if (param.flags & BIT(1)) {
++               rcar_assert_domain(param.id);
++       } else {
++               rcar_deassert_domain(param.id);
++       }
++
++       status = SCMI_SUCCESS;
++error:
++       *(int32_t *)payload = status;
++       return sizeof(status);
++}
++
++static uint32_t reset_notify(size_t channel __unused,
++                                  volatile uint8_t *param,
++                                  size_t size)
++{
++       *(int32_t *)param = SCMI_NOT_SUPPORTED;
++       return sizeof(int32_t);
++}
++
++typedef uint32_t (*reset_handler_t)(size_t, volatile uint8_t*,size_t);
++
++static reset_handler_t reset_handlers[SCMI_LAST_ID] = {
++       [PROTOCOL_VERSION] = protocol_version,
++       [PROTOCOL_ATTRIBUTES] = protocol_attrs,
++       [PROTOCOL_MESSAGE_ATTRIBUTES] = protocol_msg_attrs,
++       [RESET_DOMAIN_ATTRIBUTES] = reset_attrs,
++       [RESET] = reset,
++       [RESET_NOTIFY] = reset_notify,
++};
++
++uint32_t rcar_scmi_handle_reset(size_t channel, uint8_t cmd,
++                              volatile uint8_t *param, size_t size)
++{      if (cmd >= SCMI_LAST_ID) {
++               *(int32_t *)param = SCMI_NOT_SUPPORTED;
++               return sizeof(int32_t);
++       }
++
++       assert(reset_handlers[cmd] != NULL);
++
++       return reset_handlers[cmd](channel, param, size);
++}
++
++void rcar_reset_reset(uint32_t domain_id)
++{
++       assert(domain_id < RCAR_SCMIRST_MAX);
++       rcar_auto_domain(domain_id);
++}
++
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0007-rcar-add-SCMI-clock-protocol-implementation.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0007-rcar-add-SCMI-clock-protocol-implementation.patch
@@ -1,0 +1,671 @@
+From 4d5f3b1d89ca9e907f9ba09c7131bd9ed0d3f736 Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 14:11:34 +0200
+Subject: [PATCH 06/12] rcar: add SCMI clock protocol implementation
+
+Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+Signed-off-by: Ihor Usyk <ihor.usyk@gmail.com>
+---
+ plat/renesas/common/include/rcar_private.h    |  38 +-
+ .../common/include/rcar_scmi_resources.h      |   6 +
+ plat/renesas/rcar/platform.mk                 |   3 +-
+ plat/renesas/rcar/rcar_scmi_clocks.c          | 545 ++++++++++++++++++
+ 4 files changed, 589 insertions(+), 3 deletions(-)
+ create mode 100644 plat/renesas/rcar/rcar_scmi_clocks.c
+
+diff --git a/plat/renesas/common/include/rcar_private.h b/plat/renesas/common/include/rcar_private.h
+index feed21c3a..bbc48343d 100644
+--- a/plat/renesas/common/include/rcar_private.h
++++ b/plat/renesas/common/include/rcar_private.h
+@@ -107,6 +107,8 @@ void rcar_console_boot_end(void);
+ void rcar_console_runtime_init(void);
+ void rcar_console_runtime_end(void);
+ 
++int rcar_cpg_init(void);
++
+ #define SCMI_SUCCESS           0
+ #define SCMI_NOT_SUPPORTED     (-1)
+ #define SCMI_INVALID_PARAMETERS        (-2)
+@@ -125,9 +127,11 @@ void rcar_console_runtime_end(void);
+ #define FLD(mask, val) (((val) << (__builtin_ffsll(mask) - 1) & (mask)))
+ #define FLD_GET(mask, val) (((val) & (mask)) >> (__builtin_ffsll(mask) - 1))
+ 
+-typedef uint16_t scmi_perm_t;
++typedef uint16_t scmi_umask_t;
++
++_Static_assert(sizeof(scmi_umask_t) * 8 == RCAR_SCMI_CHAN_COUNT);
+ 
+-_Static_assert(sizeof(scmi_perm_t) * 8 == RCAR_SCMI_CHAN_COUNT);
++typedef scmi_umask_t scmi_perm_t;
+ 
+ struct scmi_reset {
+        uint16_t rst_reg;
+@@ -136,13 +140,43 @@ struct scmi_reset {
+        scmi_perm_t perm;
+ };
+ 
++union rcar_clk {
++       struct {
++               uint16_t mult;
++               uint16_t div;
++       } fixed;
++       struct {
++               uint64_t rate;
++       } extal;
++       struct {
++               uint16_t cr; /* control register */
++       } div6;
++       struct {
++               uint16_t cr; /* control register */
++               uint16_t st; /* satus register   */
++               uint8_t bit;
++               uint8_t init;/* default value    */
++       } mssr;
++};
++
++struct scmi_clk {
++       const char *name;
++       const int parent;
++       scmi_umask_t usage;
++       scmi_perm_t perm;
++       const uint8_t type;
++       const union rcar_clk clk;
++};
++
+ static inline bool scmi_permission_granted(scmi_perm_t perm, uint32_t channel)
+ {
+        assert(channel < RCAR_SCMI_CHAN_COUNT);
+        return perm & (1 << channel);
+ }
+ 
++uint32_t rcar_scmi_handle_clock(size_t, uint8_t, volatile uint8_t*, size_t);
+ uint32_t rcar_scmi_handle_reset(size_t, uint8_t, volatile uint8_t*, size_t);
++void rcar_reset_clock(uint32_t, uint32_t);
+ void rcar_reset_reset(uint32_t);
+ 
+ #endif /* RCAR_PRIVATE_H */
+diff --git a/plat/renesas/common/include/rcar_scmi_resources.h b/plat/renesas/common/include/rcar_scmi_resources.h
+index f001788e0..85219512c 100644
+--- a/plat/renesas/common/include/rcar_scmi_resources.h
++++ b/plat/renesas/common/include/rcar_scmi_resources.h
+@@ -35,6 +35,12 @@ enum rcar_scmi_rst_offset {
+        RCAR_SCMIRST_MAX
+ };
+ 
++enum rcar_scmi_clk {
++       RCAR_CLK_MAX,
++       RCAR_SCMICLK_MAX = RCAR_CLK_MAX /* end of SCMI exported clocks */
++};
++
++extern struct scmi_clk rcar_clocks[RCAR_CLK_MAX];
+ extern struct scmi_reset rcar_resets[RCAR_SCMIRST_MAX];
+ 
+ #endif /* RCAR_SCMI_RESOURCES_H */
+diff --git a/plat/renesas/rcar/platform.mk b/plat/renesas/rcar/platform.mk
+index 93fbd0d84..8129a5415 100644
+--- a/plat/renesas/rcar/platform.mk
++++ b/plat/renesas/rcar/platform.mk
+@@ -331,7 +331,8 @@ endif
+ 
+ ifeq (${RCAR_GEN3_ULCB},1)
+ BL31_SOURCES		+=	drivers/renesas/rcar/cpld/ulcb_cpld.c \
+-				plat/renesas/rcar/rcar_scmi_reset.c
++				plat/renesas/rcar/rcar_scmi_reset.c   \
++				plat/renesas/rcar/rcar_scmi_clocks.c
+ endif
+ 
+ # build the layout images for the bootrom and the necessary srecords
+diff --git a/plat/renesas/rcar/rcar_scmi_clocks.c b/plat/renesas/rcar/rcar_scmi_clocks.c
+new file mode 100644
+index 000000000..0ba91e8db
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_scmi_clocks.c
+@@ -0,0 +1,545 @@
++/*
++ * Copyright (c) 2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * Neither the name of ARM nor the names of its contributors may be used
++ * to endorse or promote products derived from this software without specific
++ * prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <lib/mmio.h>
++#include <lib/spinlock.h>
++
++#include "rcar_def.h"
++#include "rcar_private.h"
++#include "rcar_scmi_resources.h"
++
++#define CPG_BASE U(0xE6150000)
++
++enum scmi_message_id {
++       PROTOCOL_VERSION = 0x0,
++       PROTOCOL_ATTRIBUTES,
++       PROTOCOL_MESSAGE_ATTRIBUTES,
++       CLOCK_ATTRIBUTES,
++       CLOCK_DESCRIBE_RATES,
++       CLOCK_RATE_SET,
++       CLOCK_RATE_GET,
++       CLOCK_CONFIG_SET,
++       SCMI_LAST_ID
++};
++
++enum rcar_clk_type {
++       CLK_TYPE_FIXED,
++       CLK_TYPE_EXTAL,
++       CLK_TYPE_DIV6,
++       CLK_TYPE_SD,
++       CLK_TYPE_MSSR,
++};
++
++enum rcar_mssr_state {
++       MSSR_ON = 0x0,
++       MSSR_OFF,
++};
++
++struct scmi_clk_ops {
++       int (*enable)(struct scmi_clk*);
++       void (*disable)(struct scmi_clk*);
++       uint64_t (*get_rate)(struct scmi_clk*);
++       int (*set_rate)(struct scmi_clk*,uint64_t);
++       bool (*is_enabled)(struct scmi_clk*);
++};
++
++static spinlock_t clk_lock;
++
++struct scmi_clk rcar_clocks[RCAR_CLK_MAX] = {
++};
++
++static uint64_t __clk_get_rate_locked(uint32_t);
++
++static uint64_t extal_clk_get_rate(struct scmi_clk *sclk)
++{
++       assert(sclk);
++       return sclk->clk.extal.rate;
++}
++
++static bool extal_clk_is_enabled(struct scmi_clk *sclk)
++{
++       return true;
++}
++
++static const struct scmi_clk_ops extal_clk_ops = {
++       .get_rate = extal_clk_get_rate,
++       .is_enabled = extal_clk_is_enabled,
++};
++
++static uint64_t fixed_clk_get_rate(struct scmi_clk *sclk)
++{
++       uint64_t rate;
++
++       assert(sclk);
++       assert(sclk->parent >= 0);
++
++       rate = __clk_get_rate_locked(sclk->parent);
++       rate *= sclk->clk.fixed.mult;
++       rate /= sclk->clk.fixed.div;
++       return rate;
++}
++
++static bool fixed_clk_is_enabled(struct scmi_clk *sclk)
++{
++       return true;
++}
++
++static const struct scmi_clk_ops fixed_clk_ops = {
++       .get_rate = fixed_clk_get_rate,
++       .is_enabled = fixed_clk_is_enabled,
++};
++
++static uint64_t mssr_clk_get_rate(struct scmi_clk *sclk)
++{
++       assert(sclk);
++       assert(sclk->parent >= 0);
++       return __clk_get_rate_locked(sclk->parent);
++}
++
++static int mssr_clk_enable(struct scmi_clk *sclk)
++{
++       uint32_t value;
++       uintptr_t ctl_reg = CPG_BASE + sclk->clk.mssr.cr;
++       uintptr_t status_reg = CPG_BASE + sclk->clk.mssr.st;
++       uint32_t mask = BIT(sclk->clk.mssr.bit);
++
++       value = mmio_read_32(ctl_reg);
++       value &= ~mask;
++       mmio_write_32(ctl_reg, value);
++
++       for (int i = 0; i < 1000; i++) {
++               if (!(mmio_read_32(status_reg) & mask)) {
++                       return SCMI_SUCCESS;
++               }
++       }
++
++       ERROR("failed to enable clock %s\n", sclk->name);
++       return SCMI_HARDWARE_ERROR;
++}
++
++static void mssr_clk_disable(struct scmi_clk *sclk)
++{
++       uint32_t value;
++       uintptr_t ctl_reg = CPG_BASE + sclk->clk.mssr.cr;
++       uint32_t mask = BIT(sclk->clk.mssr.bit);
++
++       value = mmio_read_32(ctl_reg);
++       value |= mask;
++       mmio_write_32(ctl_reg, value);
++}
++
++static bool mssr_clk_is_enabled(struct scmi_clk *sclk)
++{
++       uintptr_t status_reg = CPG_BASE + sclk->clk.mssr.st;
++       uint32_t value = mmio_read_32(status_reg);
++
++       return !(value & BIT(sclk->clk.mssr.bit));
++}
++
++static const struct scmi_clk_ops mssr_clk_ops = {
++       .enable = mssr_clk_enable,
++       .disable = mssr_clk_disable,
++       .get_rate = mssr_clk_get_rate,
++       .is_enabled = mssr_clk_is_enabled,
++};
++
++static inline struct scmi_clk * __clk_get(uint32_t id)
++{
++       assert(id < ARRAY_SIZE(rcar_clocks));
++       return &rcar_clocks[id];
++}
++
++static inline const char * __clk_get_name(uint32_t id)
++{
++       struct scmi_clk * sclk = __clk_get(id);
++       return sclk->name;
++}
++
++static const struct scmi_clk_ops * __clk_get_ops(struct scmi_clk *sclk)
++{
++       assert(sclk);
++
++       switch (sclk->type) {
++       case CLK_TYPE_FIXED:
++               return &fixed_clk_ops;
++       case CLK_TYPE_EXTAL:
++               return &extal_clk_ops;
++       case CLK_TYPE_MSSR:
++               return &mssr_clk_ops;
++       case CLK_TYPE_DIV6:
++       case CLK_TYPE_SD:
++       default:
++               ERROR("unsupported clock type 0x%x\n", sclk->type);
++               assert(false);
++       }
++
++       /* should not reach here */
++}
++
++static uint64_t __clk_get_rate_locked(uint32_t id)
++{
++       struct scmi_clk *sclk = __clk_get(id);
++       const struct scmi_clk_ops *ops = __clk_get_ops(sclk);
++
++       assert(ops->get_rate);
++       return ops->get_rate(sclk);
++}
++
++static bool __clk_enabled(uint32_t id)
++{
++       struct scmi_clk *sclk = __clk_get(id);
++       const struct scmi_clk_ops *ops = __clk_get_ops(sclk);
++
++       assert(ops->is_enabled);
++
++       return ops->is_enabled(sclk);
++}
++
++static void __clk_disable_locked(uint32_t id, uint32_t channel)
++{
++       struct scmi_clk *sclk = __clk_get(id);
++       const struct scmi_clk_ops *ops = __clk_get_ops(sclk);
++
++       sclk->usage &= ~(1 << channel);
++
++       if (sclk->usage == 0 && ops->disable) {
++               ops->disable(sclk);
++       }
++
++       if (sclk->parent >= 0) {
++               __clk_disable_locked(sclk->parent, channel);
++       }
++}
++
++static int __clk_enable_locked(uint32_t id, uint32_t channel)
++{
++       struct scmi_clk *sclk = __clk_get(id);
++       const struct scmi_clk_ops *ops = __clk_get_ops(sclk);
++
++       if (sclk->parent >= 0) {
++               int res = __clk_enable_locked(sclk->parent, channel);
++               if (res) {
++                       return res;
++               }
++       }
++
++       if (sclk->usage == 0 && ops->enable) {
++               int res = ops->enable(sclk);
++               if (res) {
++                       __clk_disable_locked(sclk->parent, channel);
++                       return res;
++               }
++       }
++
++       sclk->usage |= 1 << channel;
++       return SCMI_SUCCESS;
++}
++
++static uint32_t protocol_version(size_t channel __unused,
++                                volatile uint8_t *param,
++                                size_t size __unused)
++{
++       int32_t *status = (int32_t*)param;
++       uint32_t *version = (uint32_t*)(param + sizeof(*status));
++       *status = SCMI_SUCCESS;
++       *version = 0x10000; /* DEN0056C, 4.6.2.1 */
++       return sizeof(*status) + sizeof(*version);
++}
++
++static uint32_t protocol_attrs(size_t channel __unused,
++                              volatile uint8_t *param,
++                              size_t size __unused)
++{
++       int32_t *status = (int32_t*)param;
++       uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++
++       *status = SCMI_SUCCESS;
++       *attrs = FLD(GENMASK(31, 16), 0) |
++                FLD(GENMASK(15,  0), RCAR_SCMICLK_MAX);
++
++       return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t protocol_msg_attrs(size_t channel __unused,
++                                  volatile uint8_t *param,
++                                  size_t size)
++{
++       uint32_t id = *(uint32_t*)param;
++       int32_t *status = (int32_t*)param;
++       uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++
++       if (size != sizeof(id)) {
++               *status = SCMI_PROTOCOL_ERROR;
++               return sizeof(*status);
++       }
++
++       /* all commands are mandatory */
++       *status = SCMI_SUCCESS;
++       *attrs = 0x0;
++
++       return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t clk_attrs(size_t channel, volatile uint8_t *param, size_t size)
++{
++       struct clk_discovery {
++               int32_t status;
++               uint32_t attributes;
++               char name[16];
++       } *res = (struct clk_discovery*)param;
++       uint32_t clock_id = *(uint32_t*)param;
++
++       if (size != sizeof(clock_id)) {
++               res->status = SCMI_PROTOCOL_ERROR;
++               return sizeof(res->status);
++       }
++
++       if (clock_id >= RCAR_SCMICLK_MAX) {
++               res->status = SCMI_NOT_FOUND;
++               return sizeof(res->status);
++       }
++
++       if (!scmi_permission_granted(rcar_clocks[clock_id].perm, channel)) {
++               res->status = SCMI_DENIED;
++               return sizeof(res->status);
++       }
++
++       res->attributes = __clk_enabled(clock_id) ? BIT(0) : 0;
++
++       assert(__clk_get_name(clock_id) != NULL);
++       strlcpy(res->name, __clk_get_name(clock_id), sizeof(res->name));
++
++       res->status = SCMI_SUCCESS;
++
++       return sizeof(*res);
++}
++
++static uint32_t set_rate(size_t channel __unused,
++                             volatile uint8_t *param,
++                             size_t size __unused)
++{
++       *(int32_t *)param = SCMI_NOT_SUPPORTED;
++       return sizeof(int32_t);
++}
++
++static uint64_t clk_get_rate(uint32_t clock_id)
++{
++       int ret;
++       spin_lock(&clk_lock);
++       ret = __clk_get_rate_locked(clock_id);
++       spin_unlock(&clk_lock);
++       return ret;
++}
++
++/*TODO: not conforming to SCMI spec */
++static uint32_t get_rates(size_t channel,
++                         volatile uint8_t *payload,
++                         size_t size)
++{
++       struct parameters {
++               uint32_t id;
++               uint32_t rate_index;
++       } param = *((struct parameters*)payload);
++       struct clk_rates {
++               int32_t status;
++               uint32_t num_rates_flags;
++               uint32_t rates[2];
++       } *res = (struct clk_rates*)payload;
++       uint64_t rate;
++
++       if (size != sizeof(param)) {
++               res->status = SCMI_PROTOCOL_ERROR;
++               return sizeof(res->status);
++       }
++
++       if (param.id >= RCAR_SCMICLK_MAX) {
++               res->status = SCMI_NOT_FOUND;
++               return sizeof(res->status);
++       }
++
++       if (!scmi_permission_granted(rcar_clocks[param.id].perm, channel)) {
++               res->status = SCMI_DENIED;
++               return sizeof(res->status);
++       }
++
++       rate = clk_get_rate(param.id);
++       /*TODO: only constant rate clocks supported for now */
++       res->num_rates_flags = FLD(GENMASK(31,12), 0) | FLD(GENMASK(11,0), 1);
++       res->rates[0] = (rate >>  0) & GENMASK(31,0); /* lower word */
++       res->rates[1] = (rate >> 32) & GENMASK(31,0); /* upper word */
++       res->status = SCMI_SUCCESS;
++
++       return sizeof(*res);
++}
++
++static uint32_t get_rate(size_t channel, volatile uint8_t *param, size_t size)
++{
++       struct clk_rate {
++               int32_t status;
++               uint32_t rate[2];
++       } *res = (struct clk_rate*)param;
++       uint32_t clock_id = *(uint32_t*)param;
++       uint64_t rate;
++
++       if (size != sizeof(clock_id)) {
++               res->status = SCMI_PROTOCOL_ERROR;
++               return sizeof(res->status);
++       }
++
++       if (clock_id >= RCAR_SCMICLK_MAX) {
++               res->status = SCMI_NOT_FOUND;
++               return sizeof(res->status);
++       }
++
++       if (!scmi_permission_granted(rcar_clocks[clock_id].perm, channel)) {
++               res->status = SCMI_DENIED;
++               return sizeof(res->status);
++       }
++
++       rate = clk_get_rate(clock_id);
++       res->rate[0] = (rate >>  0) & GENMASK(31,0); /* lower word */
++       res->rate[1] = (rate >> 32) & GENMASK(31,0); /* upper word */
++       res->status = SCMI_SUCCESS;
++
++       return sizeof(*res);
++}
++
++static int clk_enable(uint32_t id, uint32_t channel)
++{
++       int ret;
++       spin_lock(&clk_lock);
++       ret = __clk_enable_locked(id, channel);
++       spin_unlock(&clk_lock);
++       return ret;
++}
++
++static void clk_disable(uint32_t id, uint32_t channel)
++{
++       spin_lock(&clk_lock);
++       __clk_disable_locked(id, channel);
++       spin_unlock(&clk_lock);
++}
++
++static uint32_t set_cfg(size_t channel, volatile uint8_t *payload, size_t size)
++{
++
++       struct parameters {
++               uint32_t id;
++               uint32_t attributes;
++       } param = *((struct parameters*)payload);
++       int32_t status = SCMI_SUCCESS;
++
++       if (size != sizeof(param)) {
++               status = SCMI_PROTOCOL_ERROR;
++               goto error;
++       }
++
++       if (param.id >= RCAR_SCMICLK_MAX) {
++               status = SCMI_NOT_FOUND;
++               goto error;
++       }
++
++       if (!scmi_permission_granted(rcar_clocks[param.id].perm, channel)) {
++               status = SCMI_DENIED;
++               goto error;
++       }
++
++       if (param.attributes & ~BIT(0)) {
++               status = SCMI_INVALID_PARAMETERS;
++               goto error;
++       }
++
++       if (param.attributes & BIT(0)) {
++               status = clk_enable(param.id, channel);
++       } else {
++               clk_disable(param.id, channel);
++       }
++
++error:
++       *(int32_t *)payload = status;
++       return sizeof(status);
++}
++
++typedef uint32_t (*clock_handler_t)(size_t, volatile uint8_t*,size_t);
++
++static clock_handler_t clock_handlers[SCMI_LAST_ID] = {
++       [PROTOCOL_VERSION] = protocol_version,
++       [PROTOCOL_ATTRIBUTES] = protocol_attrs,
++       [PROTOCOL_MESSAGE_ATTRIBUTES] = protocol_msg_attrs,
++       [CLOCK_ATTRIBUTES] = clk_attrs,
++       [CLOCK_DESCRIBE_RATES] = get_rates,
++       [CLOCK_RATE_SET] = set_rate,
++       [CLOCK_RATE_GET] = get_rate,
++       [CLOCK_CONFIG_SET] = set_cfg,
++};
++
++uint32_t rcar_scmi_handle_clock(size_t channel, uint8_t cmd,
++                              volatile uint8_t *param, size_t size)
++{      if (cmd >= SCMI_LAST_ID) {
++               *(int32_t *)param = SCMI_NOT_SUPPORTED;
++               return sizeof(int32_t);
++       }
++
++       assert(clock_handlers[cmd] != NULL);
++
++       return clock_handlers[cmd](channel, param, size);
++}
++
++void rcar_reset_clock(uint32_t id, uint32_t agent_id)
++{
++       struct scmi_clk *sclk = __clk_get(id);
++       switch (sclk->type) {
++       case CLK_TYPE_MSSR:
++               if (sclk->clk.mssr.init == MSSR_OFF) {
++                       clk_disable(id, agent_to_channel(agent_id));
++               } else {
++                       clk_enable(id, agent_to_channel(agent_id));
++               }
++               break;
++       case CLK_TYPE_DIV6:
++               WARN("div6 clocks not supported yet\n");
++               break;
++
++       case CLK_TYPE_FIXED:
++       case CLK_TYPE_EXTAL:
++       case CLK_TYPE_SD:
++               ERROR("reset of core clock requested");
++               break;
++       default:
++               ERROR("requested reset of unknown clock type %d\n", sclk->type);
++               assert(false);
++       }
++}
++
++int rcar_cpg_init(void)
++{
++       return 0;
++}
++
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0008-rcar-add-SCMI-stub-power-protocol-implementation.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0008-rcar-add-SCMI-stub-power-protocol-implementation.patch
@@ -1,0 +1,249 @@
+From 8425051e38674671fad0f9995be68c00e87687f2 Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 14:17:48 +0200
+Subject: [PATCH 07/12] rcar: add SCMI stub power protocol implementation
+
+This driver does not actually manage R-Car power, but merely keeps Linux
+scmi_pm_domain driver happy by successful replies
+
+Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+Signed-off-by: Ihor Usyk <ihor.usyk@gmail.com>
+---
+ plat/renesas/common/include/rcar_private.h |   1 +
+ plat/renesas/rcar/platform.mk              |   1 +
+ plat/renesas/rcar/rcar_scmi_power.c        | 199 +++++++++++++++++++++
+ 3 files changed, 201 insertions(+)
+ create mode 100644 plat/renesas/rcar/rcar_scmi_power.c
+
+diff --git a/plat/renesas/common/include/rcar_private.h b/plat/renesas/common/include/rcar_private.h
+index bbc48343d..1e57dc60f 100644
+--- a/plat/renesas/common/include/rcar_private.h
++++ b/plat/renesas/common/include/rcar_private.h
+@@ -174,6 +174,7 @@ static inline bool scmi_permission_granted(scmi_perm_t perm, uint32_t channel)
+        return perm & (1 << channel);
+ }
+ 
++uint32_t rcar_scmi_handle_power(size_t, uint8_t, volatile uint8_t*, size_t);
+ uint32_t rcar_scmi_handle_clock(size_t, uint8_t, volatile uint8_t*, size_t);
+ uint32_t rcar_scmi_handle_reset(size_t, uint8_t, volatile uint8_t*, size_t);
+ void rcar_reset_clock(uint32_t, uint32_t);
+diff --git a/plat/renesas/rcar/platform.mk b/plat/renesas/rcar/platform.mk
+index 8129a5415..bebe3c108 100644
+--- a/plat/renesas/rcar/platform.mk
++++ b/plat/renesas/rcar/platform.mk
+@@ -331,6 +331,7 @@ endif
+ 
+ ifeq (${RCAR_GEN3_ULCB},1)
+ BL31_SOURCES		+=	drivers/renesas/rcar/cpld/ulcb_cpld.c \
++				plat/renesas/rcar/rcar_scmi_power.c   \
+ 				plat/renesas/rcar/rcar_scmi_reset.c   \
+ 				plat/renesas/rcar/rcar_scmi_clocks.c
+ endif
+diff --git a/plat/renesas/rcar/rcar_scmi_power.c b/plat/renesas/rcar/rcar_scmi_power.c
+new file mode 100644
+index 000000000..95bcf1a7f
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_scmi_power.c
+@@ -0,0 +1,199 @@
++/*
++ * Copyright (c) 2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * Neither the name of ARM nor the names of its contributors may be used
++ * to endorse or promote products derived from this software without specific
++ * prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <assert.h>
++
++#include "rcar_private.h"
++#include "rcar_scmi_resources.h"
++
++enum scmi_message_id {
++	PROTOCOL_VERSION = 0x0,
++	PROTOCOL_ATTRIBUTES,
++	PROTOCOL_MESSAGE_ATTRIBUTES,
++	POWER_DOMAIN_ATTRIBUTES,
++	POWER_STATE_SET,
++	POWER_STATE_GET,
++	POWER_STATE_NOTIFY,
++	POWER_STATE_CHANGE_REQUESTED_NOTIFY,
++	SCMI_LAST_ID
++};
++
++static uint32_t global_power_state = 0;
++
++static uint32_t protocol_version(size_t channel __unused,
++				 volatile uint8_t *param,
++				 size_t size __unused)
++{
++	int32_t *status = (int32_t*)param;
++	uint32_t *version = (uint32_t*)(param + sizeof(*status));
++	*status = SCMI_SUCCESS;
++	*version = 0x21000; /* DEN0056C, 4.3.2.1 */
++	return sizeof(*status) + sizeof(*version);
++}
++
++static uint32_t protocol_attrs(size_t channel __unused,
++			       volatile uint8_t *param,
++			       size_t size __unused)
++{
++	struct proto_attrs {
++		int32_t status;
++		uint32_t attributes;
++		uint32_t statistic_addr[2];
++		uint32_t statistic_len;
++	} *res = (struct proto_attrs*)param;
++
++	res->status = SCMI_SUCCESS;
++	/*TODO: single stub domain for now */
++	res->attributes = FLD(GENMASK(31, 16), 0) |
++			  FLD(GENMASK(15,  0), 1);
++	res->statistic_len = 0;
++
++	return sizeof(*res);
++}
++
++static uint32_t protocol_msg_attrs(size_t channel __unused,
++				   volatile uint8_t *param,
++				   size_t size)
++{
++	uint32_t id = *(uint32_t*)param;
++	int32_t *status = (int32_t*)param;
++	uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++
++	if (size != sizeof(id)) {
++		*status = SCMI_PROTOCOL_ERROR;
++		return sizeof(*status);
++	}
++
++	/* notifications not supported in synchronous SCP implementation */
++	if (id == POWER_STATE_NOTIFY ||
++	    id == POWER_STATE_CHANGE_REQUESTED_NOTIFY)
++	{
++		*status = SCMI_NOT_FOUND;
++	} else {
++		*status = SCMI_SUCCESS;
++	}
++
++	*attrs = 0x0;
++
++	return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t power_attrs(size_t channel __unused,
++			    volatile uint8_t *param,
++			    size_t size __unused)
++{
++	struct power_discovery {
++		int32_t status;
++		uint32_t attributes;
++		char name[16];
++	} *res = (struct power_discovery*)param;
++
++	/*TODO: stub implementation, single same domain only */
++	res->status = SCMI_SUCCESS;
++	res->attributes = 0;
++	strlcpy(res->name, "scmi_core", sizeof(res->name));
++	return sizeof(*res);
++}
++
++static uint32_t power_state_set(size_t channel __unused,
++				 volatile uint8_t *payload,
++				 size_t size)
++{
++	struct parameters {
++		uint32_t flags;
++		uint32_t domain_id;
++		uint32_t state;
++	} param = *((struct parameters*)payload);
++	int32_t status = SCMI_SUCCESS;
++
++	if (size != sizeof(param)) {
++		status = SCMI_PROTOCOL_ERROR;
++		goto error;
++	}
++
++	global_power_state = param.state;
++error:
++	*(int32_t *)payload = status;
++	return sizeof(status);
++}
++
++static uint32_t power_state_get(size_t channel __unused,
++				 volatile uint8_t *param,
++				 size_t size)
++{
++	struct power_state {
++		int32_t status;
++		uint32_t state;
++	} *res = (struct power_state*)param;
++	uint32_t domain_id = *(uint32_t*)param;
++
++	if (size != sizeof(domain_id)) {
++		res->status = SCMI_PROTOCOL_ERROR;
++		return sizeof(res->status);
++	}
++
++	res->state = global_power_state;
++	res->status = SCMI_SUCCESS;
++
++	return sizeof(*res);
++}
++
++static uint32_t not_supported(size_t channel __unused,
++			      volatile uint8_t *param,
++			      size_t size)
++{
++	*(int32_t *)param = SCMI_NOT_SUPPORTED;
++	return sizeof(int32_t);
++}
++
++typedef uint32_t (*power_handler_t)(size_t, volatile uint8_t*,size_t);
++
++static power_handler_t power_handlers[SCMI_LAST_ID] = {
++	[PROTOCOL_VERSION] = protocol_version,
++	[PROTOCOL_ATTRIBUTES] = protocol_attrs,
++	[PROTOCOL_MESSAGE_ATTRIBUTES] = protocol_msg_attrs,
++	[POWER_DOMAIN_ATTRIBUTES] = power_attrs,
++	[POWER_STATE_SET] = power_state_set,
++	[POWER_STATE_GET] = power_state_get,
++	[POWER_STATE_NOTIFY] = not_supported,
++	[POWER_STATE_CHANGE_REQUESTED_NOTIFY] = not_supported,
++};
++
++uint32_t rcar_scmi_handle_power(size_t channel, uint8_t cmd,
++			       volatile uint8_t *param, size_t size)
++{	if (cmd >= SCMI_LAST_ID) {
++		*(int32_t *)param = SCMI_NOT_SUPPORTED;
++		return sizeof(int32_t);
++	}
++
++	assert(power_handlers[cmd] != NULL);
++
++	return power_handlers[cmd](channel, param, size);
++}
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0008-sip_sv-rollback-the-service-to-support-scmi.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0008-sip_sv-rollback-the-service-to-support-scmi.patch
@@ -1,0 +1,143 @@
+From fcc7d51144872d4be76859b461d75f3a5b9f7668 Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 16:45:27 +0200
+Subject: [PATCH 08/12] sip_sv: rollback the service to support scmi
+
+The SIP serviceis necessary because SCMI communication is based
+at this service
+
+Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>
+---
+ plat/renesas/common/include/rcar_sip_svc.h | 33 ++++++++++++
+ plat/renesas/rcar/platform.mk              |  3 +-
+ plat/renesas/rcar/rcar_sip_svc.c           | 63 ++++++++++++++++++++++
+ 3 files changed, 98 insertions(+), 1 deletion(-)
+ create mode 100644 plat/renesas/common/include/rcar_sip_svc.h
+ create mode 100644 plat/renesas/rcar/rcar_sip_svc.c
+
+diff --git a/plat/renesas/common/include/rcar_sip_svc.h b/plat/renesas/common/include/rcar_sip_svc.h
+new file mode 100644
+index 000000000..d9cd173d0
+--- /dev/null
++++ b/plat/renesas/common/include/rcar_sip_svc.h
+@@ -0,0 +1,33 @@
++/*
++ * Copyright (c) 2018-2020, Renesas Electronics Corporation. All rights reserved.
++ *
++ * SPDX-License-Identifier: BSD-3-Clause
++ */
++
++#ifndef RCAR_SIP_SVC_H__
++#define RCAR_SIP_SVC_H__
++
++#include <lib/utils_def.h>
++
++
++/* General Service Queries */
++#define RCAR_SIP_SVC_CALL_COUNT		U(0x8200ff00)
++#define RCAR_SIP_SVC_UID		U(0x8200ff01)
++#define RCAR_SIP_SVC_VERSION		U(0x8200ff03)
++
++/* Function ID to get the Board type */
++#define RCAR_SIP_SVC_GET_BOARD_TYPE	U(0x82000001)
++
++/* Rcar SiP Service Calls version numbers */
++#define RCAR_SIP_SVC_VERSION_MAJOR	U(0x0)
++#define RCAR_SIP_SVC_VERSION_MINOR	U(0x2)
++
++/* Number of function IDs excluding general service queries */
++#define RCAR_SIP_SVC_FUNCTION_NUM	U(0x1)
++
++#define RCAR_SMC_RET_SUCCESS		0
++#define RCAR_SMC_RET_EFAILED		-2
++#define RCAR_SMC_RET_PMIC_DISABLE	-3
++
++
++#endif /* RCAR_SIP_SVC_H__ */
+\ No newline at end of file
+diff --git a/plat/renesas/rcar/platform.mk b/plat/renesas/rcar/platform.mk
+index bebe3c108..7b3c20c2d 100644
+--- a/plat/renesas/rcar/platform.mk
++++ b/plat/renesas/rcar/platform.mk
+@@ -333,7 +333,8 @@ ifeq (${RCAR_GEN3_ULCB},1)
+ BL31_SOURCES		+=	drivers/renesas/rcar/cpld/ulcb_cpld.c \
+ 				plat/renesas/rcar/rcar_scmi_power.c   \
+ 				plat/renesas/rcar/rcar_scmi_reset.c   \
+-				plat/renesas/rcar/rcar_scmi_clocks.c
++				plat/renesas/rcar/rcar_scmi_clocks.c  \
++        plat/renesas/rcar/rcar_sip_svc.c
+ endif
+ 
+ # build the layout images for the bootrom and the necessary srecords
+diff --git a/plat/renesas/rcar/rcar_sip_svc.c b/plat/renesas/rcar/rcar_sip_svc.c
+new file mode 100644
+index 000000000..1c9884065
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_sip_svc.c
+@@ -0,0 +1,63 @@
++/*
++ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
++ * Copyright (c) 2018-2021, Renesas Electronics Corporation. All rights reserved.
++ *
++ * SPDX-License-Identifier: BSD-3-Clause
++*/
++
++#include <common/runtime_svc.h>
++#include <tools_share/uuid.h>
++#include <common/debug.h>
++#include <rcar_sip_svc.h>
++#include "board.h"
++
++/*
++ * This function handles Rcar defined SiP Calls
++*/
++static uintptr_t rcar_sip_handler(unsigned int smc_fid,
++			u_register_t x1,
++			u_register_t x2,
++			u_register_t x3,
++			u_register_t x4,
++			void *cookie,
++			void *handle,
++			u_register_t flags)
++{
++#if PMIC_ROHM_BD9571
++	int32_t		ret;
++#endif	/* PMIC_ROHM_BD9571 */
++	/* Rcar SiP Service UUID */
++	DEFINE_SVC_UUID2(rcar_sip_svc_uid,
++			0x120f8108U, 0x8152U, 0x4154U, 0xa2U, 0xafU,
++			0x7dU, 0x8aU, 0x7eU, 0x6dU, 0x90U, 0xeeU);
++
++	switch (smc_fid) {
++	case RCAR_SIP_SVC_CALL_COUNT:
++		/* Return the number of function IDs */
++		SMC_RET1(handle, RCAR_SIP_SVC_FUNCTION_NUM);
++
++	case RCAR_SIP_SVC_UID:
++		/* Return UID to the caller */
++		SMC_UUID_RET(handle, rcar_sip_svc_uid);
++
++	case RCAR_SIP_SVC_VERSION:
++		/* Return the version of current implementation */
++		SMC_RET2(handle, RCAR_SIP_SVC_VERSION_MAJOR,
++			RCAR_SIP_SVC_VERSION_MINOR);
++
++	default:
++		WARN("Unimplemented Rcar SiP Service Call: 0x%x\n", smc_fid);
++		SMC_RET1(handle, SMC_UNK);
++	}
++
++}
++
++/* Define a runtime service descriptor for fast SMC calls */
++DECLARE_RT_SVC(
++	rcar_sip_svc,
++	(uint8_t)OEN_SIP_START,
++	(uint8_t)OEN_SIP_END,
++	(uint8_t)SMC_TYPE_FAST,
++	NULL,
++	rcar_sip_handler
++);
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0009-rcar-SCMI-base-protocol-implementation-and-handling.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0009-rcar-SCMI-base-protocol-implementation-and-handling.patch
@@ -1,0 +1,785 @@
+From 9940e0bf05cbaca49ea3d56e2d2f146e04a35be4 Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 17:02:18 +0200
+Subject: [PATCH 09/12] rcar: SCMI base protocol implementation and handling
+
+Add SCMI base procol commands handling.
+
+Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+Signed-off-by: Ihor Usyk <ihor.usyk@gmail.com>
+---
+ plat/renesas/common/include/rcar_private.h    |  12 +
+ .../common/include/rcar_scmi_resources.h      |   5 +
+ plat/renesas/common/include/rcar_sip_svc.h    |   5 +-
+ plat/renesas/rcar/platform.mk                 |   3 +
+ plat/renesas/rcar/rcar_scmi.c                 | 136 ++++++
+ plat/renesas/rcar/rcar_scmi_base.c            | 426 ++++++++++++++++++
+ plat/renesas/rcar/rcar_scmi_devices.c         |  41 ++
+ plat/renesas/rcar/rcar_sip_svc.c              |  12 +-
+ 8 files changed, 638 insertions(+), 2 deletions(-)
+ create mode 100644 plat/renesas/rcar/rcar_scmi.c
+ create mode 100644 plat/renesas/rcar/rcar_scmi_base.c
+ create mode 100644 plat/renesas/rcar/rcar_scmi_devices.c
+
+diff --git a/plat/renesas/common/include/rcar_private.h b/plat/renesas/common/include/rcar_private.h
+index 1e57dc60f..a6a08253a 100644
+--- a/plat/renesas/common/include/rcar_private.h
++++ b/plat/renesas/common/include/rcar_private.h
+@@ -107,7 +107,10 @@ void rcar_console_boot_end(void);
+ void rcar_console_runtime_init(void);
+ void rcar_console_runtime_end(void);
+ 
++uint32_t rcar_trigger_scmi(size_t);
++int rcar_setup_scmi(void);
+ int rcar_cpg_init(void);
++uint32_t scmi_count_protocols(void);
+ 
+ #define SCMI_SUCCESS           0
+ #define SCMI_NOT_SUPPORTED     (-1)
+@@ -127,12 +130,20 @@ int rcar_cpg_init(void);
+ #define FLD(mask, val) (((val) << (__builtin_ffsll(mask) - 1) & (mask)))
+ #define FLD_GET(mask, val) (((val) & (mask)) >> (__builtin_ffsll(mask) - 1))
+ 
++#define channel_to_agent(channel) ((channel) + 1)
++#define agent_to_channel(agent) ((agent) - 1)
++
+ typedef uint16_t scmi_umask_t;
+ 
+ _Static_assert(sizeof(scmi_umask_t) * 8 == RCAR_SCMI_CHAN_COUNT);
+ 
+ typedef scmi_umask_t scmi_perm_t;
+ 
++struct scmi_device {
++       int *rsts;
++       int *clks;
++};
++
+ struct scmi_reset {
+        uint16_t rst_reg;
+        uint16_t clr_reg;
+@@ -174,6 +185,7 @@ static inline bool scmi_permission_granted(scmi_perm_t perm, uint32_t channel)
+        return perm & (1 << channel);
+ }
+ 
++uint32_t rcar_scmi_handle_base(size_t, uint8_t, volatile uint8_t*, size_t);
+ uint32_t rcar_scmi_handle_power(size_t, uint8_t, volatile uint8_t*, size_t);
+ uint32_t rcar_scmi_handle_clock(size_t, uint8_t, volatile uint8_t*, size_t);
+ uint32_t rcar_scmi_handle_reset(size_t, uint8_t, volatile uint8_t*, size_t);
+diff --git a/plat/renesas/common/include/rcar_scmi_resources.h b/plat/renesas/common/include/rcar_scmi_resources.h
+index 85219512c..8cd3611e4 100644
+--- a/plat/renesas/common/include/rcar_scmi_resources.h
++++ b/plat/renesas/common/include/rcar_scmi_resources.h
+@@ -31,6 +31,10 @@
+ #ifndef RCAR_SCMI_RESOURCES_H
+ #define RCAR_SCMI_RESOURCES_H
+ 
++enum rcar_scmi_devid {
++       RCAR_SCMIDEV_MAX
++};
++
+ enum rcar_scmi_rst_offset {
+        RCAR_SCMIRST_MAX
+ };
+@@ -40,6 +44,7 @@ enum rcar_scmi_clk {
+        RCAR_SCMICLK_MAX = RCAR_CLK_MAX /* end of SCMI exported clocks */
+ };
+ 
++extern const struct scmi_device rcar_devices[RCAR_SCMIDEV_MAX];
+ extern struct scmi_clk rcar_clocks[RCAR_CLK_MAX];
+ extern struct scmi_reset rcar_resets[RCAR_SCMIRST_MAX];
+ 
+diff --git a/plat/renesas/common/include/rcar_sip_svc.h b/plat/renesas/common/include/rcar_sip_svc.h
+index d9cd173d0..e676a16db 100644
+--- a/plat/renesas/common/include/rcar_sip_svc.h
++++ b/plat/renesas/common/include/rcar_sip_svc.h
+@@ -18,6 +18,9 @@
+ /* Function ID to get the Board type */
+ #define RCAR_SIP_SVC_GET_BOARD_TYPE	U(0x82000001)
+ 
++/* SCMI doorbell */
++#define RCAR_SIP_SVC_MBOX_TRIGGER      U(0x82000002)
++
+ /* Rcar SiP Service Calls version numbers */
+ #define RCAR_SIP_SVC_VERSION_MAJOR	U(0x0)
+ #define RCAR_SIP_SVC_VERSION_MINOR	U(0x2)
+@@ -30,4 +33,4 @@
+ #define RCAR_SMC_RET_PMIC_DISABLE	-3
+ 
+ 
+-#endif /* RCAR_SIP_SVC_H__ */
+\ No newline at end of file
++#endif /* RCAR_SIP_SVC_H__ */
+diff --git a/plat/renesas/rcar/platform.mk b/plat/renesas/rcar/platform.mk
+index 7b3c20c2d..75d2aead9 100644
+--- a/plat/renesas/rcar/platform.mk
++++ b/plat/renesas/rcar/platform.mk
+@@ -331,6 +331,9 @@ endif
+ 
+ ifeq (${RCAR_GEN3_ULCB},1)
+ BL31_SOURCES		+=	drivers/renesas/rcar/cpld/ulcb_cpld.c \
++                                plat/renesas/rcar/rcar_scmi.c         \
++                                plat/renesas/rcar/rcar_scmi_base.c    \
++                                plat/renesas/rcar/rcar_scmi_devices.c \
+ 				plat/renesas/rcar/rcar_scmi_power.c   \
+ 				plat/renesas/rcar/rcar_scmi_reset.c   \
+ 				plat/renesas/rcar/rcar_scmi_clocks.c  \
+diff --git a/plat/renesas/rcar/rcar_scmi.c b/plat/renesas/rcar/rcar_scmi.c
+new file mode 100644
+index 000000000..5995161c2
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_scmi.c
+@@ -0,0 +1,136 @@
++/*
++ * Copyright (c) 2016,2017 ARM Limited and Contributors. All rights reserved.
++ * Copyright (c) 2017,2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * Neither the name of ARM nor the names of its contributors may be used
++ * to endorse or promote products derived from this software without specific
++ * prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <assert.h>
++#include <common/debug.h>
++#include <lib/mmio.h>
++#include <lib/smccc.h>
++
++#include "rcar_def.h"
++#include "rcar_private.h"
++
++#define RCAR_SCMI_SHMEM_BASE	DRAM2_NS_SCMI_BASE /* va == pa */
++
++enum scmi_protocol_id {
++	SCMI_BASE_PROTO  = 0x10,
++	SCMI_POWER_PROTO = 0x11,
++	SCMI_CLOCK_PROTO = 0x14,
++	SCMI_RESET_PROTO = 0x16,
++	SCMI_LAST_PROTO
++};
++
++typedef volatile struct scmi_shared_mem {
++	 uint32_t reserved;
++	 uint32_t channel_status;
++	 uint32_t reserved1[2];
++	 uint32_t flags;
++	 uint32_t length;
++	 uint32_t msg_header;
++	 uint8_t msg_payload[];
++} scmi_shmem_t;
++
++static uint32_t scmi_handle_default(size_t channel __unused,
++				    uint8_t cmd __unused,
++				    volatile uint8_t *param,
++				    size_t size __unused)
++{
++	*(int32_t *)param = SCMI_NOT_SUPPORTED;
++	return sizeof(int32_t);
++}
++
++typedef uint32_t (*proto_handler_t)(size_t,uint8_t,volatile uint8_t*,size_t);
++
++static proto_handler_t proto_handlers[SCMI_LAST_PROTO] = {
++	[0 ... SCMI_LAST_PROTO - 1] = scmi_handle_default,
++	[SCMI_BASE_PROTO]  = rcar_scmi_handle_base,
++	[SCMI_POWER_PROTO]  = rcar_scmi_handle_power,
++	[SCMI_CLOCK_PROTO] = rcar_scmi_handle_clock,
++	[SCMI_RESET_PROTO] = rcar_scmi_handle_reset,
++};
++
++static uint32_t scmi_handle_cmd(size_t ch, uint8_t protocol, uint8_t cmd,
++				volatile uint8_t *payload,
++				size_t payload_size)
++{
++	if (protocol < ARRAY_SIZE(proto_handlers)) {
++		return proto_handlers[protocol](ch, cmd, payload, payload_size);
++	}
++
++	*(int32_t *)payload = SCMI_NOT_SUPPORTED;
++	return sizeof(int32_t);
++}
++
++uint32_t scmi_count_protocols(void)
++{
++	uint32_t count = 0;
++	for (int i = 0; i < ARRAY_SIZE(proto_handlers); i++) {
++		if (proto_handlers[i] != scmi_handle_default) {
++			count++;
++		}
++	}
++	return count;
++}
++
++int rcar_setup_scmi(void)
++{
++	return rcar_cpg_init();
++}
++
++uint32_t rcar_trigger_scmi(size_t chan_id)
++{
++	scmi_shmem_t *shmem;
++	size_t payload_size;
++	uint8_t protocol_id, message_id;
++
++	if (chan_id >= RCAR_SCMI_CHAN_COUNT) {
++		return SMC_ARCH_CALL_INVAL_PARAM;
++	}
++
++	shmem = (struct scmi_shared_mem *)
++		(RCAR_SCMI_SHMEM_BASE + chan_id * PAGE_SIZE);
++	payload_size = MAX(sizeof(shmem->msg_header),(size_t)shmem->length);
++	payload_size -= sizeof(shmem->msg_header);
++	protocol_id = FLD_GET(GENMASK(17,10), shmem->msg_header);
++	message_id = FLD_GET(GENMASK(7,0), shmem->msg_header);
++
++	VERBOSE("BL31-SCMI: channel: 0x%lx, protocol: 0x%x, command: 0x%x\n",
++		chan_id, protocol_id, message_id);
++
++	shmem->length = scmi_handle_cmd(chan_id, protocol_id, message_id,
++					shmem->msg_payload, payload_size);
++
++	assert(shmem->length + sizeof(*shmem) < PAGE_SIZE);
++	shmem->length += sizeof(shmem->msg_header);
++	shmem->channel_status = BIT(0); /* mark free */
++	flush_dcache_range((uintptr_t)shmem, sizeof(*shmem) + shmem->length);
++
++	return SMC_ARCH_CALL_SUCCESS;
++}
+diff --git a/plat/renesas/rcar/rcar_scmi_base.c b/plat/renesas/rcar/rcar_scmi_base.c
+new file mode 100644
+index 000000000..1ba01fa4d
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_scmi_base.c
+@@ -0,0 +1,426 @@
++/*
++ * Copyright (c) 2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * Neither the name of ARM nor the names of its contributors may be used
++ * to endorse or promote products derived from this software without specific
++ * prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include <assert.h>
++#include <common/debug.h>
++
++#include "rcar_def.h"
++#include "rcar_private.h"
++#include "rcar_scmi_resources.h"
++
++enum scmi_message_id {
++	PROTOCOL_VERSION = 0x0,
++	PROTOCOL_ATTRIBUTES,
++	PROTOCOL_MESSAGE_ATTRIBUTES,
++	BASE_DISCOVER_VENDOR,
++	BASE_DISCOVER_SUB_VENDOR,
++	BASE_DISCOVER_IMPLEMENTATION_VERSION,
++	BASE_DISCOVER_LIST_PROTOCOLS,
++	BASE_DISCOVER_AGENT,
++	BASE_NOTIFY_ERRORS,
++	BASE_SET_DEVICE_PERMISSIONS,
++	BASE_SET_PROTOCOL_PERMISSIONS,
++	BASE_RESET_AGENT_CONFIGURATION,
++	SCMI_LAST_ID
++};
++
++static uint32_t protocol_version(size_t channel __unused,
++				 volatile uint8_t *param,
++				 size_t size __unused)
++{
++	int32_t *status = (int32_t*)param;
++	uint32_t *version = (uint32_t*)(param + sizeof(*status));
++	*status = SCMI_SUCCESS;
++	*version = SCMI_PROTOCOL_VERSION;
++	return sizeof(*status) + sizeof(*version);
++}
++
++static uint32_t protocol_attrs(size_t channel __unused,
++			       volatile uint8_t *param,
++			       size_t size __unused)
++{
++	int32_t *status = (int32_t*)param;
++	uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++	uint32_t num_proto = scmi_count_protocols();
++
++	*status = SCMI_SUCCESS;
++	*attrs = FLD(GENMASK(31, 16), 0) |
++		 FLD(GENMASK(15, 8), RCAR_SCMI_CHAN_COUNT) |
++		 FLD(GENMASK(7,  0), num_proto);
++
++	return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t protocol_msg_attrs(size_t channel __unused,
++				   volatile uint8_t *param,
++				   size_t size)
++{
++	uint32_t id = *(uint32_t*)param;
++	int32_t *status = (int32_t*)param;
++	uint32_t *attrs = (uint32_t*)(param + sizeof(*status));
++
++	if (size != sizeof(id)) {
++		*status = SCMI_PROTOCOL_ERROR;
++		return sizeof(*status);
++	}
++
++	/* BASE_NOTIFY_ERRORS not supported in synchronous SCP implementation
++	 * BASE_SET_PROTOCOL_PERMISSIONS not implemented yet
++	*/
++	if (id == BASE_NOTIFY_ERRORS || id == BASE_SET_PROTOCOL_PERMISSIONS) {
++		*status = SCMI_NOT_FOUND;
++	} else {
++		*status = SCMI_SUCCESS;
++	}
++
++	*attrs = 0x0;
++
++	return sizeof(*status) + sizeof(*attrs);
++}
++
++static uint32_t __copy_vendor_str(volatile uint8_t *param,
++				  const char src[], size_t len)
++{
++	struct vendor {
++		int32_t status;
++		char name[16];
++	} *res = (struct vendor*)param;
++
++	assert(len <= sizeof(res->name));
++
++	strlcpy(res->name, src, len);
++	res->status = SCMI_SUCCESS;
++
++	return sizeof(*res);
++}
++
++static uint32_t get_vendor(size_t channel __unused,
++			   volatile uint8_t *param,
++			   size_t size __unused)
++{
++	return __copy_vendor_str(param, "ATF\0", 4);
++}
++
++static uint32_t get_sub_vendor(size_t channel __unused,
++			       volatile uint8_t *param,
++			       size_t size __unused)
++{
++	return __copy_vendor_str(param, "R-Car\0", 6);
++}
++
++static uint32_t impl_version(size_t channel __unused,
++			     volatile uint8_t *param,
++			     size_t size __unused)
++{
++	int32_t *status = (int32_t*)param;
++	uint32_t *version = (uint32_t*)(param + sizeof(*status));
++	*status = SCMI_SUCCESS;
++	*version = 0x1001;
++	return sizeof(*status) + sizeof(*version);
++}
++
++static uint32_t get_protocols(size_t channel __unused,
++			      volatile uint8_t *param,
++			      size_t size)
++{
++	struct protocols_response {
++		int32_t status;
++		uint32_t num_protocols;
++		uint32_t protocols;
++	} *res = (struct protocols_response*)param;
++	uint32_t skip = *(uint32_t*)param;
++
++	if (size != sizeof(skip)) {
++		res->status = SCMI_PROTOCOL_ERROR;
++		return sizeof(res->status);
++	}
++
++	if (skip != 0) {
++		res->status = SCMI_INVALID_PARAMETERS;
++		return sizeof(res->status);
++	}
++
++	res->status = SCMI_SUCCESS;
++	res->num_protocols = scmi_count_protocols();
++	/*FIXME: get supported protocols from rcar_scmi.c */
++	res->protocols = FLD(GENMASK(23,16), 0x11) |
++			 FLD(GENMASK(15,8), 0x14)  |
++			 FLD(GENMASK(7,0), 0x16);
++
++	return sizeof(*res);
++}
++
++static uint32_t get_agent(size_t channel, volatile uint8_t *param, size_t size)
++{
++	struct agent_discovery {
++		int32_t status;
++		uint32_t agent_id;
++		char name[16];
++	} *res = (struct agent_discovery*)param;
++	uint32_t agent_id = *(uint32_t*)param;
++
++	if (size != sizeof(agent_id)) {
++		res->status = SCMI_PROTOCOL_ERROR;
++		return sizeof(res->status);
++	}
++
++	if (agent_id == 0xFFFFFFFF) {
++		agent_id = channel_to_agent(channel);
++	}
++
++	switch (agent_id) {
++	case 0:
++		strlcpy(res->name, "platform ATF", sizeof(res->name));
++		break;
++	case 1:
++		strlcpy(res->name, "HYP", sizeof(res->name));
++		break;
++	case 2 ... RCAR_SCMI_CHAN_COUNT:
++		snprintf(res->name, sizeof(res->name), "VM%u", agent_id - 2);
++		break;
++	default:
++		res->status = SCMI_NOT_FOUND;
++		return sizeof(res->status);
++	}
++
++	res->agent_id = agent_id;
++	res->status = SCMI_SUCCESS;
++
++	return sizeof(*res);
++}
++
++static uint32_t notify_errors(size_t channel __unused,
++			      volatile uint8_t *param,
++			      size_t size __unused)
++{
++	*(int32_t *)param = SCMI_NOT_SUPPORTED;
++	return sizeof(int32_t);
++}
++
++static inline void __set_perm(scmi_perm_t *perm, uint32_t agent_id, bool permit)
++{
++	scmi_perm_t mask = 1 << agent_to_channel(agent_id);
++	if (permit) {
++		*perm |= mask;
++	} else {
++		*perm &= ~mask;
++	}
++}
++
++static inline void __scmi_permit(scmi_perm_t *perm, uint32_t agent_id)
++{
++	__set_perm(perm, agent_id, true);
++}
++
++static inline void __scmi_deny(scmi_perm_t *perm, uint32_t agent_id)
++{
++	__set_perm(perm, agent_id, false);
++}
++
++static inline void __mangle_dev_perm(uint32_t agent_id, uint32_t dev_id,
++				  void (*fn)(scmi_perm_t*, uint32_t))
++{
++#define MANGLE(attr, devs) {\
++	int *index = rcar_devices[dev_id].attr; \
++	while (index && *index >= 0) { \
++		fn(&devs[*index++].perm, agent_id); \
++	} \
++}
++	assert(dev_id < RCAR_SCMIDEV_MAX);
++	assert(agent_id <= RCAR_SCMI_CHAN_COUNT);
++	MANGLE(rsts, rcar_resets);
++	MANGLE(clks, rcar_clocks);
++#undef MANGLE
++}
++
++static inline void scmi_permit(uint32_t agent_id, uint32_t dev_id)
++{
++	__mangle_dev_perm(agent_id, dev_id, __scmi_permit);
++}
++
++static inline void scmi_deny(uint32_t agent_id, uint32_t dev_id)
++{
++	__mangle_dev_perm(agent_id, dev_id, __scmi_deny);
++}
++
++static inline void scmi_drop_permissions(uint32_t agent_id)
++{
++	assert(agent_id <= RCAR_SCMI_CHAN_COUNT);
++	for (uint32_t dev_id = 0; dev_id < RCAR_SCMIDEV_MAX; dev_id++) {
++		scmi_deny(agent_id, dev_id);
++	}
++}
++
++static uint32_t set_dev_perm(size_t channel,
++			     volatile uint8_t *payload,
++			     size_t size)
++{
++	struct parameters {
++		uint32_t agent_id;
++		uint32_t device_id;
++		uint32_t flags;
++	} param = *((struct parameters*)payload);
++	int32_t status;
++
++	if (channel != 0) {
++		status = SCMI_DENIED;
++		goto error;
++	}
++
++	if (size != sizeof(param)) {
++		status = SCMI_PROTOCOL_ERROR;
++		goto error;
++	}
++
++	if (param.agent_id > RCAR_SCMI_CHAN_COUNT ||
++	    param.device_id >= RCAR_SCMIDEV_MAX)
++	{
++		status = SCMI_NOT_FOUND;
++		goto error;
++	}
++
++	if (param.flags & ~0x1) {
++		status = SCMI_INVALID_PARAMETERS;
++		goto error;
++	}
++
++
++	if (param.flags & 0x1) {
++		scmi_permit(param.agent_id, param.device_id);
++	} else {
++		scmi_deny(param.agent_id, param.device_id);
++	}
++
++	status = SCMI_SUCCESS;
++error:
++	*(int32_t *)payload = status;
++	return sizeof(status);
++}
++
++/* Not implemented yet */
++static uint32_t set_protocol_perm(size_t channel __unused,
++			      volatile uint8_t *param,
++			      size_t size __unused)
++{
++	*(int32_t *)param = SCMI_NOT_SUPPORTED;
++	return sizeof(int32_t);
++}
++
++static void reset_agent_resources(uint32_t agent_id)
++{
++	uint32_t channel = agent_to_channel(agent_id);
++	for (uint32_t id = 0; id < RCAR_SCMICLK_MAX; id++) {
++		struct scmi_clk *sclk = &rcar_clocks[id];
++		if (!scmi_permission_granted(sclk->perm, channel)) {
++			continue;
++		}
++		rcar_reset_clock(id, agent_id);
++	}
++
++	for (uint32_t id = 0; id < RCAR_SCMIRST_MAX; id++) {
++		struct scmi_reset *rst = &rcar_resets[id];
++		if (!scmi_permission_granted(rst->perm, channel)) {
++			continue;
++		}
++		rcar_reset_reset(id);
++	}
++}
++
++static uint32_t reset_agent(size_t channel,
++			     volatile uint8_t *param,
++			     size_t size)
++{
++	uint32_t agent_id = *(uint32_t*)param;
++	uint32_t flags = *(uint32_t*)(param + sizeof(agent_id));
++	int32_t status;
++
++	if (size != sizeof(agent_id) + sizeof(flags)) {
++		status = SCMI_PROTOCOL_ERROR;
++		goto error;
++	}
++
++	if (agent_id > RCAR_SCMI_CHAN_COUNT) {
++		status = SCMI_NOT_FOUND;
++		goto error;
++	}
++
++	if (agent_id != channel_to_agent(channel) && channel != 0) {
++		status = SCMI_DENIED;
++		goto error;
++
++	}
++
++	if (flags & ~0x1) {
++		status = SCMI_INVALID_PARAMETERS;
++		goto error;
++	}
++
++	reset_agent_resources(agent_id);
++
++	/* check if need to reset access permissions */
++	if (flags & 0x1) {
++		scmi_drop_permissions(agent_id);
++	}
++
++	status = SCMI_SUCCESS;
++error:
++	*(int32_t *)param = status;
++	return sizeof(status);
++}
++
++typedef uint32_t (*base_handler_t)(size_t, volatile uint8_t*,size_t);
++
++static base_handler_t base_handlers[SCMI_LAST_ID] = {
++	[PROTOCOL_VERSION] = protocol_version,
++	[PROTOCOL_ATTRIBUTES] = protocol_attrs,
++	[PROTOCOL_MESSAGE_ATTRIBUTES] = protocol_msg_attrs,
++	[BASE_DISCOVER_VENDOR] = get_vendor,
++	[BASE_DISCOVER_SUB_VENDOR] = get_sub_vendor,
++	[BASE_DISCOVER_IMPLEMENTATION_VERSION] = impl_version,
++	[BASE_DISCOVER_LIST_PROTOCOLS] = get_protocols,
++	[BASE_DISCOVER_AGENT] = get_agent,
++	[BASE_NOTIFY_ERRORS] = notify_errors,
++	[BASE_SET_DEVICE_PERMISSIONS] = set_dev_perm,
++	[BASE_SET_PROTOCOL_PERMISSIONS] = set_protocol_perm,
++	[BASE_RESET_AGENT_CONFIGURATION] = reset_agent,
++};
++
++uint32_t rcar_scmi_handle_base(size_t channel, uint8_t cmd,
++			       volatile uint8_t *param, size_t size)
++{
++	if (cmd >= SCMI_LAST_ID) {
++		*(int32_t *)param = SCMI_NOT_SUPPORTED;
++		return sizeof(int32_t);
++	}
++
++	assert(base_handlers[cmd] != NULL);
++
++	return base_handlers[cmd](channel, param, size);
++}
+diff --git a/plat/renesas/rcar/rcar_scmi_devices.c b/plat/renesas/rcar/rcar_scmi_devices.c
+new file mode 100644
+index 000000000..c63b7fe67
+--- /dev/null
++++ b/plat/renesas/rcar/rcar_scmi_devices.c
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (c) 2021 EPAM Systems Inc. All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * Redistributions of source code must retain the above copyright notice, this
++ * list of conditions and the following disclaimer.
++ *
++ * Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * Neither the name of ARM nor the names of its contributors may be used
++ * to endorse or promote products derived from this software without specific
++ * prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++
++#include "rcar_private.h"
++#include "rcar_scmi_resources.h"
++
++static const struct scmi_device default_dev = {
++		.rsts = (int[]){-1},
++		.clks = (int[]){-1},
++};
++
++const struct scmi_device rcar_devices[RCAR_SCMIDEV_MAX] = {
++	[0 ... RCAR_SCMIDEV_MAX - 1] = default_dev, /* sentinel */
++};
+diff --git a/plat/renesas/rcar/rcar_sip_svc.c b/plat/renesas/rcar/rcar_sip_svc.c
+index 1c9884065..da802bafa 100644
+--- a/plat/renesas/rcar/rcar_sip_svc.c
++++ b/plat/renesas/rcar/rcar_sip_svc.c
+@@ -10,6 +10,12 @@
+ #include <common/debug.h>
+ #include <rcar_sip_svc.h>
+ #include "board.h"
++#include "rcar_private.h"
++
++static int rcar_sip_setup(void)
++{
++	return rcar_setup_scmi();
++}
+ 
+ /*
+  * This function handles Rcar defined SiP Calls
+@@ -36,6 +42,10 @@ static uintptr_t rcar_sip_handler(unsigned int smc_fid,
+ 		/* Return the number of function IDs */
+ 		SMC_RET1(handle, RCAR_SIP_SVC_FUNCTION_NUM);
+ 
++	case RCAR_SIP_SVC_MBOX_TRIGGER:
++                ret = rcar_trigger_scmi(SMC_GET_GP(handle, CTX_GPREG_X7));
++		SMC_RET1(handle, ret);
++
+ 	case RCAR_SIP_SVC_UID:
+ 		/* Return UID to the caller */
+ 		SMC_UUID_RET(handle, rcar_sip_svc_uid);
+@@ -58,6 +68,6 @@ DECLARE_RT_SVC(
+ 	(uint8_t)OEN_SIP_START,
+ 	(uint8_t)OEN_SIP_END,
+ 	(uint8_t)SMC_TYPE_FAST,
+-	NULL,
++	rcar_sip_setup,
+ 	rcar_sip_handler
+ );
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0010-rcar-scmi-add-physical-resources-to-SCMI-devices.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0010-rcar-scmi-add-physical-resources-to-SCMI-devices.patch
@@ -1,0 +1,997 @@
+From 72e23717ae4c95df29be5c617c168c8a5d3dc3c8 Mon Sep 17 00:00:00 2001
+From: Ihor Usyk <ihor_usyk@epam.com>
+Date: Mon, 12 Jun 2023 17:15:13 +0200
+Subject: [PATCH 10/12] rcar: scmi: add physical resources to SCMI devices
+
+Put HW descriptions for EAVB, USB, I2C and audio controllers under
+corresponding drivers management.
+
+Signed-off-by: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>
+---
+ .../common/include/rcar_scmi_resources.h      | 108 +++-
+ plat/renesas/rcar/rcar_scmi_clocks.c          | 557 ++++++++++++++++++
+ plat/renesas/rcar/rcar_scmi_devices.c         | 110 ++++
+ plat/renesas/rcar/rcar_scmi_reset.c           | 145 +++++
+ 4 files changed, 918 insertions(+), 2 deletions(-)
+
+diff --git a/plat/renesas/common/include/rcar_scmi_resources.h b/plat/renesas/common/include/rcar_scmi_resources.h
+index 8cd3611e4..d31fe2dc0 100644
+--- a/plat/renesas/common/include/rcar_scmi_resources.h
++++ b/plat/renesas/common/include/rcar_scmi_resources.h
+@@ -32,16 +32,120 @@
+ #define RCAR_SCMI_RESOURCES_H
+ 
+ enum rcar_scmi_devid {
+-       RCAR_SCMIDEV_MAX
++	RCAR_SCMIDEV_EAVB,	/*  0 */
++	RCAR_SCMIDEV_HDMI0,	/*  1 */
++	RCAR_SCMIDEV_HDMI1,	/*  2 */
++	RCAR_SCMIDEV_I2C0,	/*  3 */
++	RCAR_SCMIDEV_I2C1,	/*  4 */
++	RCAR_SCMIDEV_I2C2,	/*  5 */
++	RCAR_SCMIDEV_I2C3,	/*  6 */
++	RCAR_SCMIDEV_I2C4,	/*  7 */
++	RCAR_SCMIDEV_XHCI0,	/*  8 */
++	RCAR_SCMIDEV_OHCI0,	/*  9 */
++	RCAR_SCMIDEV_EHCI0,	/* 10 */
++	RCAR_SCMIDEV_OHCI1,	/* 11 */
++	RCAR_SCMIDEV_EHCI1,	/* 12 */
++	RCAR_SCMIDEV_USB_DMAC0,	/* 13 */
++	RCAR_SCMIDEV_USB_DMAC1,	/* 14 */
++	RCAR_SCMIDEV_USB_DMAC2,	/* 15 */
++	RCAR_SCMIDEV_USB_DMAC3,	/* 16 */
++	RCAR_SCMIDEV_USB2_PHY0,	/* 17 */
++	RCAR_SCMIDEV_USB2_PHY1,	/* 18 */
++	RCAR_SCMIDEV_HSUSB,	/* 19 */
++	RCAR_SCMIDEV_SOUND,	/* 20 */
++	RCAR_SCMIDEV_AUDMA0,	/* 21 */
++	RCAR_SCMIDEV_AUDMA1,	/* 22 */
++ 	RCAR_SCMIDEV_MAX
+ };
+ 
+ enum rcar_scmi_rst_offset {
++	RCAR_SCMIRST_EAVB,	/*  0*/
++	RCAR_SCMIRST_HDMI0,	/*  1 */
++	RCAR_SCMIRST_HDMI1,	/*  2 */
++	RCAR_SCMIRST_I2C0,	/*  3 */
++	RCAR_SCMIRST_I2C1,	/*  4 */
++	RCAR_SCMIRST_I2C2,	/*  5 */
++	RCAR_SCMIRST_I2C3,	/*  6 */
++	RCAR_SCMIRST_I2C4,	/*  7 */
++	RCAR_SCMIRST_XHCI0,	/*  8 */
++	RCAR_SCMIRST_USB2_01,	/*  9 */
++	RCAR_SCMIRST_USB2_02,	/* 10 */
++	RCAR_SCMIRST_USB2_1,	/* 11 */
++	RCAR_SCMIRST_USB_DMAC0,	/* 12 */
++	RCAR_SCMIRST_USB_DMAC1,	/* 13 */
++	RCAR_SCMIRST_USB_DMAC2,	/* 14 */
++	RCAR_SCMIRST_USB_DMAC3,	/* 15 */
++	RCAR_SCMIRST_SSI,	/* 16 */
++	RCAR_SCMIRST_SSI9,	/* 17 */
++	RCAR_SCMIRST_SSI8,	/* 18 */
++	RCAR_SCMIRST_SSI7,	/* 19 */
++	RCAR_SCMIRST_SSI6,	/* 20 */
++	RCAR_SCMIRST_SSI5,	/* 21 */
++	RCAR_SCMIRST_SSI4,	/* 22 */
++	RCAR_SCMIRST_SSI3,	/* 23 */
++	RCAR_SCMIRST_SSI2,	/* 24 */
++	RCAR_SCMIRST_SSI1,	/* 25 */
++	RCAR_SCMIRST_SSI0,	/* 26 */
++	RCAR_SCMIRST_AUDMAC1,	/* 27 */
++	RCAR_SCMIRST_AUDMAC0,	/* 28 */
+        RCAR_SCMIRST_MAX
+ };
+ 
+ enum rcar_scmi_clk {
++	RCAR_SCMICLK_EAVB,	/*  0 */
++	RCAR_SCMICLK_XHCI0,	/*  1 */
++	RCAR_SCMICLK_EHCI0,	/*  2 */
++	RCAR_SCMICLK_HSUSB,	/*  3 */
++	RCAR_SCMICLK_EHCI1,	/*  4 */
++	RCAR_SCMICLK_USB_DMAC0,	/*  5 */
++	RCAR_SCMICLK_USB_DMAC1,	/*  6 */
++	RCAR_SCMICLK_USB_DMAC30,/*  7 */
++	RCAR_SCMICLK_USB_DMAC31,/*  8 */
++	RCAR_SCMICLK_SSI_ALL,	/*  9 */
++	RCAR_SCMICLK_SSI9,	/* 10 */
++	RCAR_SCMICLK_SSI8,	/* 11 */
++	RCAR_SCMICLK_SSI7,	/* 12 */
++	RCAR_SCMICLK_SSI6,	/* 13 */
++	RCAR_SCMICLK_SSI5,	/* 14 */
++	RCAR_SCMICLK_SSI4,	/* 15 */
++	RCAR_SCMICLK_SSI3,	/* 16 */
++	RCAR_SCMICLK_SSI2,	/* 17 */
++	RCAR_SCMICLK_SSI1,	/* 18 */
++	RCAR_SCMICLK_SSI0,	/* 19 */
++	RCAR_SCMICLK_SCU_ALL,	/* 20 */
++	RCAR_SCMICLK_SCU_DVC1,	/* 21 */
++	RCAR_SCMICLK_SCU_DVC0,	/* 22 */
++	RCAR_SCMICLK_SCU_MIX1,	/* 23 */
++	RCAR_SCMICLK_SCU_MIX0,	/* 24 */
++	RCAR_SCMICLK_SCU_SRC9,	/* 25 */
++	RCAR_SCMICLK_SCU_SRC8,	/* 26 */
++	RCAR_SCMICLK_SCU_SRC7,	/* 27 */
++	RCAR_SCMICLK_SCU_SRC6,	/* 28 */
++	RCAR_SCMICLK_SCU_SRC5,	/* 29 */
++	RCAR_SCMICLK_SCU_SRC4,	/* 30 */
++	RCAR_SCMICLK_SCU_SRC3,	/* 31 */
++	RCAR_SCMICLK_SCU_SRC2,	/* 32 */
++	RCAR_SCMICLK_SCU_SRC1,	/* 33 */
++	RCAR_SCMICLK_SCU_SRC0,	/* 34 */
++	RCAR_SCMICLK_AUDMAC1,	/* 35 */
++	RCAR_SCMICLK_AUDMAC0,	/* 36 */
++	RCAR_SCMICLK_HDMI,
++	RCAR_SCMICLK_HDMI0,
++	RCAR_SCMICLK_HDMI1,
++	RCAR_CLK_EXTAL,
++	RCAR_CLK_MAIN,
++	RCAR_CLK_PLL1,
++	RCAR_CLK_PLL1D2,
++	RCAR_CLK_S0,
++	RCAR_CLK_S1,
++	RCAR_CLK_S3,
++	RCAR_CLK_S0D6,
++	RCAR_CLK_S1D2,
++	RCAR_CLK_S3D1,
++	RCAR_CLK_S3D2,
++	RCAR_CLK_S3D4,
+        RCAR_CLK_MAX,
+-       RCAR_SCMICLK_MAX = RCAR_CLK_MAX /* end of SCMI exported clocks */
++	RCAR_SCMICLK_MAX = RCAR_SCMICLK_HDMI /* end of SCMI exported clocks */
+ };
+ 
+ extern const struct scmi_device rcar_devices[RCAR_SCMIDEV_MAX];
+diff --git a/plat/renesas/rcar/rcar_scmi_clocks.c b/plat/renesas/rcar/rcar_scmi_clocks.c
+index 0ba91e8db..0b2b92908 100644
+--- a/plat/renesas/rcar/rcar_scmi_clocks.c
++++ b/plat/renesas/rcar/rcar_scmi_clocks.c
+@@ -36,6 +36,17 @@
+ #include "rcar_scmi_resources.h"
+ 
+ #define CPG_BASE U(0xE6150000)
++#define SMSTPCR3  0x13C
++#define SMSTPCR5  0x144
++#define SMSTPCR7  0x14C
++#define SMSTPCR8  0x990
++#define SMSTPCR10 0x998
++
++#define MSTPSR3  0x048
++#define MSTPSR5  0x03C
++#define MSTPSR7  0x1C4
++#define MSTPSR8  0x9A0
++#define MSTPSR10 0x9A8
+ 
+ enum scmi_message_id {
+        PROTOCOL_VERSION = 0x0,
+@@ -73,6 +84,552 @@ struct scmi_clk_ops {
+ static spinlock_t clk_lock;
+ 
+ struct scmi_clk rcar_clocks[RCAR_CLK_MAX] = {
++	[RCAR_SCMICLK_EAVB] = {
++		.name = "_etheravb",
++		.parent = RCAR_CLK_S0D6,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR8,
++			.st = MSTPSR8,
++			.bit = 12,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_XHCI0] = {
++		.name = "_usb3-if0",
++		.parent = RCAR_CLK_S3D1,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR3,
++			.st = MSTPSR3,
++			.bit = 28,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_EHCI0] = {
++		.name = "_ehci0",
++		.parent = RCAR_CLK_S3D2,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR7,
++			.st = MSTPSR7,
++			.bit = 3,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_HSUSB] = {
++		.name = "_hsusb",
++		.parent = RCAR_CLK_S3D2,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR7,
++			.st = MSTPSR7,
++			.bit = 4,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_EHCI1] = {
++		.name = "_ehci1",
++		.parent = RCAR_CLK_S3D2,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR7,
++			.st = MSTPSR7,
++			.bit = 2,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_USB_DMAC0] = {
++		.name = "_usb-dmac0",
++		.parent = RCAR_CLK_S3D1,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR3,
++			.st = MSTPSR3,
++			.bit = 30,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_USB_DMAC1] = {
++		.name = "_usb-dmac1",
++		.parent = RCAR_CLK_S3D1,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR3,
++			.st = MSTPSR3,
++			.bit = 31,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_USB_DMAC30] = {
++		.name = "_usb-dmac30",
++		.parent = RCAR_CLK_S3D1,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR3,
++			.st = MSTPSR3,
++			.bit = 26,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_USB_DMAC31] = {
++		.name = "_usb-dmac31",
++		.parent = RCAR_CLK_S3D1,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR3,
++			.st = MSTPSR3,
++			.bit = 29,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI_ALL] = {
++		.name = "_ssi-all",
++		.parent = RCAR_CLK_S3D4,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 5,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI9] = {
++		.name = "_ssi9",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 6,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI8] = {
++		.name = "_ssi8",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 7,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI7] = {
++		.name = "_ssi7",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 8,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI6] = {
++		.name = "_ssi6",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 9,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI5] = {
++		.name = "_ssi5",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 10,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI4] = {
++		.name = "_ssi4",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 11,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI3] = {
++		.name = "_ssi3",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 12,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI2] = {
++		.name = "_ssi2",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 13,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI1] = {
++		.name = "_ssi1",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 14,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SSI0] = {
++		.name = "_ssi0",
++		.parent = RCAR_SCMICLK_SSI_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 15,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_ALL] = {
++		.name = "_scu-all",
++		.parent = RCAR_CLK_S3D4,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 17,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_DVC1] = {
++		.name = "_scu-dvc1",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 18,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_DVC0] = {
++		.name = "_scu-dvc0",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 19,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_MIX1] = {
++		.name = "_scu-ctu1-mix1",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 20,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_MIX0] = {
++		.name = "_scu-ctu0-mix0",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 21,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC9] = {
++		.name = "_scu-src9",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 22,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC8] = {
++		.name = "_scu-src8",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 23,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC7] = {
++		.name = "_scu-src7",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 24,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC6] = {
++		.name = "_scu-src6",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 25,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC5] = {
++		.name = "_scu-src5",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 26,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC4] = {
++		.name = "_scu-src4",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 27,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC3] = {
++		.name = "_scu-src3",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 28,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC2] = {
++		.name = "_scu-src2",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 29,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC1] = {
++		.name = "_scu-src1",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 30,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_SCU_SRC0] = {
++		.name = "_scu-src0",
++		.parent = RCAR_SCMICLK_SCU_ALL,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR10,
++			.st = MSTPSR10,
++			.bit = 31,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_AUDMAC1] = {
++		.name = "_audmac1",
++		.parent = RCAR_CLK_S1D2,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR5,
++			.st = MSTPSR5,
++			.bit = 1,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_AUDMAC0] = {
++		.name = "_audmac0",
++		.parent = RCAR_CLK_S1D2,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR5,
++			.st = MSTPSR5,
++			.bit = 2,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_HDMI] = {
++		.name = "_hdmi",
++		.parent = -1, /*TODO: div6 clocks support */
++		.type = CLK_TYPE_DIV6,
++		.clk.div6 = {
++			.cr = 0x250,
++		}
++	},
++	[RCAR_SCMICLK_HDMI0] = {
++		.name = "_hdmi0",
++		.parent = RCAR_SCMICLK_HDMI,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR7,
++			.st = MSTPSR7,
++			.bit = 29,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_SCMICLK_HDMI1] = {
++		.name = "_hdmi1",
++		.parent = RCAR_SCMICLK_HDMI,
++		.type = CLK_TYPE_MSSR,
++		.clk.mssr = {
++			.cr = SMSTPCR7,
++			.st = MSTPSR7,
++			.bit = 28,
++			.init = MSSR_OFF,
++		}
++	},
++	[RCAR_CLK_EXTAL] = {
++		.name = "extal",
++		.parent = -1,
++		.type = CLK_TYPE_EXTAL,
++		.clk.extal = {
++			.rate = 16666666,
++		}
++	},
++	[RCAR_CLK_MAIN] = {
++		.name = ".main",
++		.parent = RCAR_CLK_EXTAL,
++		.type = CLK_TYPE_FIXED,
++		/*TODO: should be set according to mode pins */
++		.clk.fixed = {
++			.div = 1,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_PLL1] = {
++		.name = ".pll1",
++		.parent = RCAR_CLK_MAIN,
++		.type = CLK_TYPE_FIXED,
++		/*TODO: should be set according to mode pins */
++		.clk.fixed = {
++			.div = 1,
++			.mult = 192,
++		}
++	},
++	[RCAR_CLK_PLL1D2] = {
++		.name = ".pll1_div2",
++		.parent = RCAR_CLK_PLL1,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 2,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S0] = {
++		.name = ".s0",
++		.parent = RCAR_CLK_PLL1D2,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 2,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S1] = {
++		.name = ".s1",
++		.parent = RCAR_CLK_PLL1D2,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 3,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S3] = {
++		.name = ".s3",
++		.parent = RCAR_CLK_PLL1D2,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 6,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S0D6] = {
++		.name = "s0d6",
++		.parent = RCAR_CLK_S0,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 6,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S1D2] = {
++		.name = "s1d2",
++		.parent = RCAR_CLK_S1,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 2,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S3D1] = {
++		.name = "s3d1",
++		.parent = RCAR_CLK_S3,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 1,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S3D2] = {
++		.name = "s3d2",
++		.parent = RCAR_CLK_S3,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 2,
++			.mult = 1,
++		}
++	},
++	[RCAR_CLK_S3D4] = {
++		.name = "s3d4",
++		.parent = RCAR_CLK_S3,
++		.type = CLK_TYPE_FIXED,
++		.clk.fixed = {
++			.div = 4,
++			.mult = 1,
++		}
++	},
+ };
+ 
+ static uint64_t __clk_get_rate_locked(uint32_t);
+diff --git a/plat/renesas/rcar/rcar_scmi_devices.c b/plat/renesas/rcar/rcar_scmi_devices.c
+index c63b7fe67..93cc7d197 100644
+--- a/plat/renesas/rcar/rcar_scmi_devices.c
++++ b/plat/renesas/rcar/rcar_scmi_devices.c
+@@ -38,4 +38,114 @@ static const struct scmi_device default_dev = {
+ 
+ const struct scmi_device rcar_devices[RCAR_SCMIDEV_MAX] = {
+ 	[0 ... RCAR_SCMIDEV_MAX - 1] = default_dev, /* sentinel */
++
++	[RCAR_SCMIDEV_EAVB] = {
++		.rsts = (int[]){RCAR_SCMIRST_EAVB,-1},
++		.clks = (int[]){RCAR_SCMICLK_EAVB,-1},
++	},
++	[RCAR_SCMIDEV_HDMI0] = {
++		.rsts = (int[]){RCAR_SCMIRST_HDMI0,-1},
++		.clks = (int[]){RCAR_SCMICLK_HDMI,RCAR_SCMICLK_HDMI0,-1},
++	},
++	[RCAR_SCMIDEV_HDMI1] = {
++		.rsts = (int[]){RCAR_SCMIRST_HDMI1,-1},
++		.clks = (int[]){RCAR_SCMICLK_HDMI,RCAR_SCMICLK_HDMI1,-1},
++	},
++	[RCAR_SCMIDEV_I2C0] = {
++		.rsts = (int[]){RCAR_SCMIRST_I2C0,-1},
++		.clks = (int[]){-1},
++	},
++	[RCAR_SCMIDEV_I2C1] = {
++		.rsts = (int[]){RCAR_SCMIRST_I2C1,-1},
++		.clks = (int[]){-1},
++	},
++	[RCAR_SCMIDEV_I2C2] = {
++		.rsts = (int[]){RCAR_SCMIRST_I2C2,-1},
++		.clks = (int[]){-1},
++	},
++	[RCAR_SCMIDEV_I2C3] = {
++		.rsts = (int[]){RCAR_SCMIRST_I2C3,-1},
++		.clks = (int[]){-1},
++	},
++	[RCAR_SCMIDEV_I2C4] = {
++		.rsts = (int[]){RCAR_SCMIRST_I2C4,-1},
++		.clks = (int[]){-1},
++	},
++	[RCAR_SCMIDEV_XHCI0] = {
++		.rsts = (int[]){RCAR_SCMIRST_XHCI0,-1},
++		.clks = (int[]){RCAR_SCMICLK_XHCI0,-1},
++	},
++	[RCAR_SCMIDEV_OHCI0] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_01,RCAR_SCMIRST_USB2_02,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI0,RCAR_SCMICLK_HSUSB,-1},
++	},
++	[RCAR_SCMIDEV_EHCI0] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_01,RCAR_SCMIRST_USB2_02,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI0,RCAR_SCMICLK_HSUSB,-1},
++	},
++	[RCAR_SCMIDEV_OHCI1] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_1,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI1,-1},
++	},
++	[RCAR_SCMIDEV_EHCI1] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_1,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI1,-1},
++	},
++	[RCAR_SCMIDEV_USB_DMAC0] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB_DMAC0,-1},
++		.clks = (int[]){RCAR_SCMICLK_USB_DMAC0,-1},
++	},
++	[RCAR_SCMIDEV_USB_DMAC1] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB_DMAC1,-1},
++		.clks = (int[]){RCAR_SCMICLK_USB_DMAC1,-1},
++	},
++	[RCAR_SCMIDEV_USB_DMAC2] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB_DMAC2,-1},
++		.clks = (int[]){RCAR_SCMICLK_USB_DMAC30,-1},
++	},
++	[RCAR_SCMIDEV_USB_DMAC3] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB_DMAC3,-1},
++		.clks = (int[]){RCAR_SCMICLK_USB_DMAC31,-1},
++	},
++	[RCAR_SCMIDEV_USB2_PHY0] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_01,RCAR_SCMIRST_USB2_02,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI0,RCAR_SCMICLK_HSUSB,-1},
++	},
++	[RCAR_SCMIDEV_USB2_PHY1] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_1,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI1,-1},
++	},
++	[RCAR_SCMIDEV_HSUSB] = {
++		.rsts = (int[]){RCAR_SCMIRST_USB2_01,RCAR_SCMIRST_USB2_02,-1},
++		.clks = (int[]){RCAR_SCMICLK_EHCI0,RCAR_SCMICLK_HSUSB,-1},
++	},
++	[RCAR_SCMIDEV_SOUND] = {
++		.rsts = (int[]){RCAR_SCMIRST_SSI,RCAR_SCMIRST_SSI9,
++				RCAR_SCMIRST_SSI8,RCAR_SCMIRST_SSI7,
++				RCAR_SCMIRST_SSI6,RCAR_SCMIRST_SSI5,
++				RCAR_SCMIRST_SSI4,RCAR_SCMIRST_SSI3,
++				RCAR_SCMIRST_SSI2,RCAR_SCMIRST_SSI1,
++				RCAR_SCMIRST_SSI0,-1},
++		.clks = (int[]){RCAR_SCMICLK_SSI_ALL,RCAR_SCMICLK_SSI9,
++				RCAR_SCMICLK_SSI8,RCAR_SCMICLK_SSI7,
++				RCAR_SCMICLK_SSI6,RCAR_SCMICLK_SSI5,
++				RCAR_SCMICLK_SSI4,RCAR_SCMICLK_SSI3,
++				RCAR_SCMICLK_SSI2,RCAR_SCMICLK_SSI1,
++				RCAR_SCMICLK_SSI0,
++				RCAR_SCMICLK_SCU_SRC9,RCAR_SCMICLK_SCU_SRC8,
++				RCAR_SCMICLK_SCU_SRC7,RCAR_SCMICLK_SCU_SRC6,
++				RCAR_SCMICLK_SCU_SRC5,RCAR_SCMICLK_SCU_SRC4,
++				RCAR_SCMICLK_SCU_SRC3,RCAR_SCMICLK_SCU_SRC2,
++				RCAR_SCMICLK_SCU_SRC1,RCAR_SCMICLK_SCU_SRC0,
++				RCAR_SCMICLK_SCU_MIX1,RCAR_SCMICLK_SCU_MIX0,
++				RCAR_SCMICLK_SCU_DVC1,RCAR_SCMICLK_SCU_DVC0,-1},
++	},
++	[RCAR_SCMIDEV_AUDMA0] = {
++		.rsts = (int[]){RCAR_SCMIRST_AUDMAC0,-1},
++		.clks = (int[]){RCAR_SCMICLK_AUDMAC0,-1},
++	},
++	[RCAR_SCMIDEV_AUDMA1] = {
++		.rsts = (int[]){RCAR_SCMIRST_AUDMAC1,-1},
++		.clks = (int[]){RCAR_SCMICLK_AUDMAC1,-1},
++	},
+ };
+diff --git a/plat/renesas/rcar/rcar_scmi_reset.c b/plat/renesas/rcar/rcar_scmi_reset.c
+index 9947207e6..7df901913 100644
+--- a/plat/renesas/rcar/rcar_scmi_reset.c
++++ b/plat/renesas/rcar/rcar_scmi_reset.c
+@@ -38,6 +38,151 @@
+ #define CPG_BASE U(0xE6150000)
+ 
+ struct scmi_reset rcar_resets[RCAR_SCMIRST_MAX] = {
++	[RCAR_SCMIRST_EAVB] = {
++		.rst_reg = 0x920,
++		.clr_reg = 0x960,
++		.bit_off = 12,
++	},
++	[RCAR_SCMIRST_HDMI0] = {
++		.rst_reg = 0x14C,
++		.clr_reg = 0x95C,
++		.bit_off = 29,
++	},
++	[RCAR_SCMIRST_HDMI1] = {
++		.rst_reg = 0x14C,
++		.clr_reg = 0x95C,
++		.bit_off = 28,
++	},
++	[RCAR_SCMIRST_I2C0] = {
++		.rst_reg = 0x924,
++		.clr_reg = 0x964,
++		.bit_off = 31,
++	},
++	[RCAR_SCMIRST_I2C1] = {
++		.rst_reg = 0x924,
++		.clr_reg = 0x964,
++		.bit_off = 30,
++	},
++	[RCAR_SCMIRST_I2C2] = {
++		.rst_reg = 0x924,
++		.clr_reg = 0x964,
++		.bit_off = 29,
++	},
++	[RCAR_SCMIRST_I2C3] = {
++		.rst_reg = 0x924,
++		.clr_reg = 0x964,
++		.bit_off = 28,
++	},
++	[RCAR_SCMIRST_I2C4] = {
++		.rst_reg = 0x924,
++		.clr_reg = 0x964,
++		.bit_off = 27,
++	},
++	[RCAR_SCMIRST_XHCI0] = {
++		.rst_reg = 0x0B8,
++		.clr_reg = 0x94C,
++		.bit_off = 28,
++	},
++	[RCAR_SCMIRST_USB2_01] = {
++		.rst_reg = 0x1CC,
++		.clr_reg = 0x95C,
++		.bit_off = 3,
++	},
++	[RCAR_SCMIRST_USB2_02] = {
++		.rst_reg = 0x1CC,
++		.clr_reg = 0x95C,
++		.bit_off = 4,
++	},
++	[RCAR_SCMIRST_USB2_1] = {
++		.rst_reg = 0x1CC,
++		.clr_reg = 0x95C,
++		.bit_off = 2,
++	},
++	[RCAR_SCMIRST_USB_DMAC0] = {
++		.rst_reg = 0x0B8,
++		.clr_reg = 0x94C,
++		.bit_off = 30,
++	},
++	[RCAR_SCMIRST_USB_DMAC1] = {
++		.rst_reg = 0x0B8,
++		.clr_reg = 0x94C,
++		.bit_off = 31,
++	},
++	[RCAR_SCMIRST_USB_DMAC2] = {
++		.rst_reg = 0x0B8,
++		.clr_reg = 0x94C,
++		.bit_off = 26,
++	},
++	[RCAR_SCMIRST_USB_DMAC3] = {
++		.rst_reg = 0x0B8,
++		.clr_reg = 0x94C,
++		.bit_off = 29,
++	},
++	[RCAR_SCMIRST_SSI] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 5,
++	},
++	[RCAR_SCMIRST_SSI9] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 6,
++	},
++	[RCAR_SCMIRST_SSI8] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 7,
++	},
++	[RCAR_SCMIRST_SSI7] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 8,
++	},
++	[RCAR_SCMIRST_SSI6] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 9,
++	},
++	[RCAR_SCMIRST_SSI5] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 10,
++	},
++	[RCAR_SCMIRST_SSI4] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 11,
++	},
++	[RCAR_SCMIRST_SSI3] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 12,
++	},
++	[RCAR_SCMIRST_SSI2] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 13,
++	},
++	[RCAR_SCMIRST_SSI1] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 14,
++	},
++	[RCAR_SCMIRST_SSI0] = {
++		.rst_reg = 0x928,
++		.clr_reg = 0x968,
++		.bit_off = 15,
++	},
++	[RCAR_SCMIRST_AUDMAC1] = {
++		.rst_reg = 0x0C4,
++		.clr_reg = 0x954,
++		.bit_off = 1,
++	},
++	[RCAR_SCMIRST_AUDMAC0] = {
++		.rst_reg = 0x0C4,
++		.clr_reg = 0x954,
++		.bit_off = 2,
++	},
+ };
+ 
+ enum scmi_message_id {
+-- 
+2.25.1
+

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0011-bldcmd.sh-build-scmi-platform-by-default.patch
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/files/0011-bldcmd.sh-build-scmi-platform-by-default.patch
@@ -1,0 +1,22 @@
+From 440e4332e51a28409b705504b21f6a36ca198cec Mon Sep 17 00:00:00 2001
+From: Sergiy Kibrik <Sergiy_Kibrik@epam.com>
+Date: Mon, 27 Sep 2021 10:25:20 +0000
+Subject: [PATCH 11/12] bldcmd.sh: build scmi platform by default
+
+---
+ bldcmd.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bldcmd.sh b/bldcmd.sh
+index ec0bc44cf..617caebca 100644
+--- a/bldcmd.sh
++++ b/bldcmd.sh
+@@ -15,4 +15,5 @@ RCAR_BL33_EXECUTION_EL=1  \
+ RCAR_RPC_HYPERFLASH_LOCKED=0 \
+ DEBUG=1 \
+ SPD=opteed \
++RCAR_SCMI_PLATFORM=1 \
+ bl2 bl31 rcar
+-- 
+2.25.1
+


### PR DESCRIPTION
Add support of the scmi clocks to ATF.
The reason, why the scmi has been introduced is to provide the restart of the DomA domain. Without scmi protocol, the USB is not restarted what does not allow to run android GUI properly, because it requires the input device.