### PR TITLE
domd, network: set stable IP address

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-connectivity/xen-network/files/eth0.network
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-connectivity/xen-network/files/eth0.network
@@ -1,0 +1,2 @@
+[Match]
+Name=eth0

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-connectivity/xen-network/xen-network.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-connectivity/xen-network/xen-network.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files/:"

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/systemd/files/70-eth0.network
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/systemd/files/70-eth0.network
@@ -1,0 +1,9 @@
+[Match]
+Name=eth0
+ 
+[Network]
+DNS=1.1.1.1
+Address=192.168.5.81
+ 
+[Route]
+Gateway=192.168.5.1

--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_append := '${THISDIR}/files:'
+


### PR DESCRIPTION
To simplify the deployment, it has been decided to have the fixed IP addresses. Now domd, eth0 has IP = 192.168.5.85