### PR TITLE
dom0: remove core-image-thin-initramfs.bbappend

### DIFF
--- a/meta-xt-prod-cockpit-rcar-control/recipes-core/images/core-image-thin-initramfs.bbappend
+++ b/meta-xt-prod-cockpit-rcar-control/recipes-core/images/core-image-thin-initramfs.bbappend
@@ -1,1 +1,0 @@
-IMAGE_INSTALL_append = " xen-tools-xenstat"

--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -147,6 +147,7 @@ components:
         - [XEN_REL_pn-xen, "4.16"]
         - [XEN_REL_pn-xen-tools, "4.16"]
         - [SRCREV_pn-xen, "%{XT_XEN_REVISION}"]
+        - [IMAGE_INSTALL_append_pn-core-image-thin-initramfs, " xen-tools-xenstat"]
 
       layers:
         - "../meta-virtualization"


### PR DESCRIPTION
The recipe has just a declaration
IMAGE_INSTALL_append = " xen-tools-xenstat"

It is reasonable to move it into the prod-cockpit-rcar.yaml, this is the step to reduce the number of the recipes with variables declarations and without any business functionality.