### PR TITLE
domd, bmap-tools: remove recipe and declare SRC_URI in yaml file

### DIFF
--- a/meta-xt-prod-cockpit-rcar-driver-domain/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
+++ b/meta-xt-prod-cockpit-rcar-driver-domain/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
@@ -1,4 +1,0 @@
-# Intel renamed 'master' branch to 'main' so we
-# have to overwrite SRC_URI with proper branch
-SRC_URI = "git://github.com/intel/${BPN};branch=main;protocol=https"
-SRCREV = "db7087b883bf52cbff063ad17a41cc1cbb85104d"

--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -212,6 +212,10 @@ components:
         - [XEN_REL_pn-xen, "4.16"]
         - [XEN_REL_pn-xen-tools, "4.16"]
         - [SRCREV_pn-xen, "%{XT_XEN_REVISION}"]
+
+        # set bmap-tools SRC_URI
+        - [SRC_URI_pn-bmap-tools_3.5, "git://github.com/intel/${BPN};branch=main;protocol=https"]
+        - [SRCREV_pn-bmap-tools_3.5, "db7087b883bf52cbff063ad17a41cc1cbb85104d"]
         
         # add graphic packages required qt
         - [DISTRO_FEATURES_append, " pam"]


### PR DESCRIPTION
The reason of the change is to remove the recipes where just a global variables are changed. It is reasonable to declare the variables in the corresponded section of the yaml file.