### PR TITLE
bmap-tools-native: add SRC_URI to prod-cockpit-rcar.yaml

### DIFF
--- a/prod-cockpit-rcar.yaml
+++ b/prod-cockpit-rcar.yaml
@@ -216,9 +216,11 @@ components:
         - [SRCREV_pn-xen, "%{XT_XEN_REVISION}"]
 
         # set bmap-tools SRC_URI
-        - [SRC_URI_pn-bmap-tools_3.5, "git://github.com/intel/${BPN};branch=main;protocol=https"]
-        - [SRCREV_pn-bmap-tools_3.5, "db7087b883bf52cbff063ad17a41cc1cbb85104d"]
-        
+        - [SRC_URI_pn-bmap-tools, "git://github.com/intel/${BPN};branch=main;protocol=https"]
+        - [SRCREV_pn-bmap-tools, "db7087b883bf52cbff063ad17a41cc1cbb85104d"]
+        - [SRC_URI_pn-bmap-tools-native, "git://github.com/intel/${BPN};branch=main;protocol=https"]
+        - [SRCREV_pn-bmap-tools-native, "db7087b883bf52cbff063ad17a41cc1cbb85104d"]
+
         # add graphic packages required qt
         - [DISTRO_FEATURES_append, " pam"]
         - [PREFERRED_PROVIDER_virtual/egl, "libegl"]


### PR DESCRIPTION
Reason: branch master does not exist anymore