### PR TITLE
docker: fix PATH variable

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -53,4 +53,4 @@ RUN mkdir -p /home/$USER_NAME/workspace && chown $USER_NAME:$USER_NAME /home/$US
 ENV BUILD_DIR /home/$USER_NAME/workspace
 WORKDIR $BUILD_DIR
 RUN pip3 install --no-warn-script-location --user git+https://github.com/xen-troops/moulin
-ENV PATH ~/.local/bin:$PATH
+ENV PATH="/home/${USER_NAME}/.local/bin:${PATH}"


### PR DESCRIPTION
Do not use ~ in the PATH environment variable, since Docker will insert it without expansion, and
originally ~ is a bash function for
tilde expansion. Therefore, non-bash applications will not recognize that part of the PATH.
This patch also switches ENV to the original syntax.